### PR TITLE
Fix type annotations on testing Boardwalkfile.py

### DIFF
--- a/test/server-client/Boardwalkfile.py
+++ b/test/server-client/Boardwalkfile.py
@@ -1,4 +1,11 @@
-from boardwalk import AnsibleTasksType, Job, Workflow, Workspace, WorkspaceConfig
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from boardwalk import Job, Workflow, Workspace, WorkspaceConfig
+
+if TYPE_CHECKING:
+    from boardwalk import AnsibleTasksType
 
 boardwalkd_url = "http://localhost:8888/"
 


### PR DESCRIPTION
## What and why?
This fixes annotations on the Boardwalkfile.py used for testing. It was failing to import a type because we are currently using the TYPE_CHECKING conditional around the codebase
## How was this tested?
test locally
## Checklist
- [x] Have you run `make test`?
- [ ] Have you updated the VERSION file (if applicable)?
