### PR TITLE
Upgrade debian when building container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,16 @@ RUN make build
 
 FROM python:3.10-slim
 COPY --from=build /build/dist ./dist
+ENV DEBIAN_FRONTEND=noninteractive
 RUN groupadd -g 1000 not_root && useradd -u 1000 -g 1000 not_root \
+    && apt-get -y update \
+    && apt-get -y install aptitude \
+    && apt-get -y dist-upgrade \
+    && apt-get -y autoremove \
+    && apt-get -y autoclean \
+    && apt-get -y clean \
+    && aptitude -y purge '~o' \
+    && apt-get -y remove --purge aptitude \
     && python3 -m pip install ./dist/boardwalk-*.whl \
     && rm -rf ./dist
 


### PR DESCRIPTION
## What and why?
This upgrades the dockerfile so that debian is always upgraded when a new container is built. The intention of this to to ensure the OS packages are upgraded, because the upstream image isn't necessarily.
## How was this tested?
The upgraded container was tested in a live environment

