### PR TITLE
Make the test Boardwalkfile.py workflows function

### DIFF
--- a/test/server-client/Boardwalkfile.py
+++ b/test/server-client/Boardwalkfile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 from boardwalk import Job, Workflow, Workspace, WorkspaceConfig
@@ -8,6 +9,10 @@ if TYPE_CHECKING:
     from boardwalk import AnsibleTasksType
 
 boardwalkd_url = "http://localhost:8888/"
+
+# Ansible checks the envvar first for configuration; so override the location with one
+# we control so tests work.
+os.environ["ANSIBLE_CONFIG"] = os.path.abspath("ansible.cfg")
 
 
 class ShouldSucceedTestWorkspace(Workspace):

--- a/test/server-client/ansible.cfg
+++ b/test/server-client/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+inventory=./test-inventory

--- a/test/server-client/test-inventory
+++ b/test/server-client/test-inventory
@@ -1,0 +1,2 @@
+[main_hosts]
+127.0.0.1 dummyHostVar=dummyValue


### PR DESCRIPTION
Creates a minimal environment consisting of an ansible.cfg and an inventory file--with a dummy host variable in-line--required for correct execution. Fixes #29.

## What and why?
Prior to this PR, a fresh clone of this repository would not result in the test Boardwalk workflows executing correctly. This PR aims to fix that with a minimally viable configuration (an `ansible.cfg` (which references the inventory file); a `test-inventory` (which contains localhost and a dummy inventory variable[1]). With these changes, the test workflows succeed.

[1] The dummy inventory variable is required, due to various places in `boardwalk`--such as `check_host_preconditions_locally`--relying on the hostname being a key within the gathered `inventory_vars`.

## How was this tested?
Locally by executing the `ShouldSucceedTestWorkspace` and `ShouldFailTestWorkspace` workspaces (which succeeded and failed respectively). Absent the PR, they were failing to gather any hosts.

## Checklist
- [ ] Have you updated the VERSION file (if applicable)?
(Don't think this needs a version bump, since this just affects the tests.)