### PR TITLE
make .dockerignore link to .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,1 @@
-__pycache__/
-.boardwalk/
-.boardwalkd/
-.DS_store
-.idea
-.vscode/
-*.egg-info/
-build/
-dist/
+.gitignore


### PR DESCRIPTION
## What and why?
The `.dockerignore` should be ignoring the same patterns as the `.gitignore`. This makes it just link to `.gitignore` for consistency
## How was this tested?
tested by building a container
## Checklist
- [ ] Have you updated the VERSION file (if applicable)?
