### PR TITLE
Bugfix: version number wasn't appearing in container builds

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include VERSION

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 
 dist: clean
 	python3 -m pip install --upgrade build pip
-	python3 -m build . --sdist --wheel
+	python3 -m build
 
 # Applys project's required code style
 .PHONY: format


### PR DESCRIPTION
## What and why?
After switching to using a pyproject.toml, boardwalk and boardwalkd where no longer outputting the correct package version number specifically when built as a distribution package. It was appearing as `0.0.0` in on the CLI and in the UI. After some head-scratching, I realized that this issue resolves if arguments are passed to `build` explicitly. I'm assuming this might be a bug in setuptools, but I'm not entirely certain. I tried using the latest version and the situation didn't resolve.
## How was this tested?
Tested by building and running boardwalk as a container locally, which uses the dist package
## Checklist
- [x] Have you updated the VERSION file (if applicable)?
