### PR TITLE
Alpha sort CLI workspace list

### DIFF
--- a/src/boardwalk/cli_workspace.py
+++ b/src/boardwalk/cli_workspace.py
@@ -41,8 +41,10 @@ def workspace_list():
         pass
     except WorkspaceNotFound:
         pass
-    for item in Workspace.__subclasses__():
-        click.echo(item.__qualname__)
+    workspace_names: list[str] = [i.__qualname__ for i in Workspace.__subclasses__()]
+    workspace_names.sort()
+    for name in workspace_names:
+        click.echo(name)
 
 
 @workspace.command("reset", short_help="Resets active workspace")


### PR DESCRIPTION
## What and why?
This change makes it so `boardwalk workspace list` outputs alpha-sorted. This is just for better CLI UX
## How was this tested?
Tested locally
## Checklist
- [ ] Have you updated the VERSION file (if applicable)? # I would like to leave this change to be bundled with a later release
