### PR TITLE
boardwalk (feat): display --limit from CLI on web dashboard (SVRENG-336)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 
 [tool.poetry]
 name = "boardwalk"
-version = "0.8.18"
+version = "0.8.19"
 description = "Boardwalk is a linear Ansible workflow engine"
 readme = "README.md"
 authors = [

--- a/src/boardwalk/cli_run.py
+++ b/src/boardwalk/cli_run.py
@@ -556,6 +556,7 @@ def bootstrap_with_server(workspace: Workspace, ctx: click.Context):
                 workflow=workspace.cfg.workflow.__class__.__qualname__,
                 worker_command="check" if _check_mode else "run",
                 worker_hostname=socket.gethostname(),
+                worker_limit=ctx.params.get("limit"),  # type: ignore
                 worker_username=getpass.getuser(),
             )
         )

--- a/src/boardwalkd/protocol.py
+++ b/src/boardwalkd/protocol.py
@@ -49,6 +49,7 @@ class WorkspaceDetails(ProtocolBaseModel):
     workflow: str = ""
     worker_command: str = ""
     worker_hostname: str = ""
+    worker_limit: str = ""
     worker_username: str = ""
 
 

--- a/src/boardwalkd/server.py
+++ b/src/boardwalkd/server.py
@@ -660,6 +660,7 @@ class WorkspaceDetailsApiHandler(APIBaseHandler):
             f" Workflow: {workspace_details.workflow},"
             f" Worker: {workspace_details.worker_username}@{workspace_details.worker_hostname},"
             f" Host Pattern: {workspace_details.host_pattern},"
+            f" Limit Pattern: {workspace_details.worker_limit if workspace_details.worker_limit else '<unknown>'},"
             f" Command: {workspace_details.worker_command}"
         )
         event = WorkspaceEvent(severity="info", message=message)

--- a/src/boardwalkd/static/boardwalkd.css
+++ b/src/boardwalkd/static/boardwalkd.css
@@ -34,3 +34,7 @@
 .workspace-title {
     word-wrap: break-word;
 }
+
+.context-underline {
+    border-bottom: 1px dotted #000;
+}

--- a/src/boardwalkd/templates/index_workspace.html
+++ b/src/boardwalkd/templates/index_workspace.html
@@ -59,6 +59,18 @@
                             <td>{{ workspace.details.host_pattern }}</td>
                         </tr>
                         <tr>
+                            <th scope="row" title="An additional --limit applied to this workspace's Host Pattern">
+                                <span class="context-underline">Limit Pattern</span>
+                            </th>
+                            <td>
+                                {% if not workspace.details.worker_limit %}
+                                    <span class="context-underline" title="A limit was not provided--thus equivalent to 'all'--or the worker client is old and did not send a limit">&lt;unknown&gt;</span>
+                                {% else %}
+                                    {{ workspace.details.worker_limit }}
+                                {% end %}
+                            </td>
+                        </tr>
+                        <tr>
                             <th scope="row">Command</th>
                             <td>{{ workspace.details.worker_command }}</td>
                         </tr>


### PR DESCRIPTION
## What and why?
It is currently possible to provide a `--limit` when calling the 'boardwalk' command, to further restrict and sub-select the host pattern present within a Workspace's configuration. However, prior to this commit, the contents, if any, of the limit were not displayed on the boardwalkd web UI.

Thus, the `worker_limit` is added to the WorkspaceDetails model, thus allowing for the `--limit` (if any) to be sent to boardwalkd upon workflow execution.

As we use the limit as directly defined from the worker--and as it is possible to _not_ define a limit, we display 'unknown' on the UI if the limit is not defined. That could be caused by the aforementioned undefined limit--thus being equivalent to an `all` limit--or because the boardwalk client was not updated, and thus does not send the limit data in the WorkspaceDetails sent to the server upon initiation of a workflow.

Compatible with prior version, however if a `--limit` is provided in an older CLI worker, it will not be reflected on the web UI.

Resolves Issue #56.

## How was this tested?
Tested using the ShouldSucceedTestWorkspace, against the version this PR creates, as well as the prior version which doesn't send the limit. Both succeed.

## Checklist
- [x] Have you updated the `version` in the `[tool.poetry]` section of
the `pyproject.toml` file (if applicable)?
