### PR TITLE
bug: ensure boardwalk_operation is set during execution runs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 name = "boardwalk"
 description = "Boardwalk is a linear Ansible workflow engine"
 readme = "README.md"
-version = "0.8.26"
+version = "0.8.27"
 requires-python = ">=3.11,<4"
 authors = [
     {name="Mat Hornbeek", email="84995001+m4wh6k@users.noreply.github.com"},

--- a/src/boardwalk/ansible.py
+++ b/src/boardwalk/ansible.py
@@ -157,13 +157,14 @@ def ansible_runner_run_tasks(
             "gather_facts": gather_facts,
             "become": become,
             "tasks": tasks,
-            "vars": {"boardwalk_operation": True},
         }
     if job_type == boardwalk.manifest.JobTypes.PLAYBOOK:
         # Executing a (list of) playbook(s) requires some different settings
         runner_kwargs["limit"] = hosts
-        runner_kwargs["extravars"] = {"boardwalk_operation": True} | extra_vars
         runner_kwargs["playbook"] = tasks
+
+    # Load extra_vars into the runner kwargs
+    runner_kwargs["extravars"] = {"boardwalk_operation": True} | extra_vars
 
     output_msg_prefix = f"{hosts}: ansible_runner invocation"
     if limit:

--- a/test/server-client/Boardwalkfile.py
+++ b/test/server-client/Boardwalkfile.py
@@ -18,6 +18,14 @@ boardwalkd_url = "http://localhost:8888/"
 os.environ["ANSIBLE_CONFIG"] = os.path.abspath("ansible.cfg")
 
 
+class DumpHostvarsWorkspace(Workspace):
+    def config(self):
+        return WorkspaceConfig(
+            host_pattern="localhost",
+            workflow=DumpHostvarsWorkflow(),
+        )
+
+
 class ShouldSucceedTestWorkspace(Workspace):
     def config(self):
         return WorkspaceConfig(
@@ -122,6 +130,16 @@ class ShouldSucceedMixedJobTypesWorkflow(Workflow):
 
     def exit_jobs(self):
         return TestJob()
+
+
+class DumpHostvarsWorkflow(Workflow):
+    def jobs(self):
+        return DumpHostvarsJob()
+
+
+class DumpHostvarsJob(TaskJob):
+    def tasks(self) -> AnsibleTasksType:
+        return [{"ansible.builtin.debug": {"var": "hostvars[inventory_hostname]"}}]
 
 
 class TestJob(TaskJob):


### PR DESCRIPTION
## What and why?

It was discovered that the `boardwalk_operation` fact, intended to signal to other Ansible tasks that Boardwalk is running on a host, was not being set with TaskJob-type Jobs.

We mitigate this here by setting `runner_kwargs["extravars"]` with both `boardwalk_operation` and any defined `extra_vars`, for both TaskJob and PlaybookJob.

Internal ref: OPSYSENG-1287

## How was this tested?

### Example run before the change

```
asullivan@MBP-NT9RPG2XV7 server-client % boardwalk version                            
0.8.26
asullivan@MBP-NT9RPG2XV7 server-client % boardwalk workspace show                     
DumpHostvarsWorkspace
asullivan@MBP-NT9RPG2XV7 server-client % boardwalk run           
2026-02-26 13:49:25.606 | INFO     | boardwalk.cli_run:run:125 - Using workspace: DumpHostvarsWorkspace
2026-02-26 13:49:25.618 | INFO     | boardwalk.cli_run:filter_hosts_by_limit:375 - Reading inventory to process any --limit
2026-02-26 13:49:25.618 | INFO     | boardwalk.ansible:ansible_inventory:192 - Processing ansible-inventory
BECOME password: 
2026-02-26 13:49:31.831 | INFO     | boardwalk.cli_run:run_workflow:268 - 127.0.0.1: Workflow iteration on host 1 of 1
2026-02-26 13:49:31.847 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:172 - 127.0.0.1: ansible_runner invocation: check_remote_host_lock
2026-02-26 13:49:33.097 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:172 - 127.0.0.1: ansible_runner invocation: lock_remote_host
2026-02-26 13:49:37.268 | INFO     | boardwalk.cli_run:update_host_facts_in_local_state:596 - 127.0.0.1: Updating Ansible facts in local state
2026-02-26 13:49:37.271 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:172 - 127.0.0.1: ansible_runner invocation: gather_facts
2026-02-26 13:49:38.844 | INFO     | boardwalk.cli_run:execute_host_workflow:708 - 127.0.0.1: Updating remote state
2026-02-26 13:49:38.857 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:172 - 127.0.0.1: ansible_runner invocation: get_remote_state
2026-02-26 13:49:41.538 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:172 - 127.0.0.1: ansible_runner invocation: set_remote_state
2026-02-26 13:49:47.096 | INFO     | boardwalk.cli_run:execute_workflow_jobs:670 - 127.0.0.1: Running workflow main jobs
2026-02-26 13:49:47.102 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:172 - 127.0.0.1: ansible_runner invocation: main_TASK_Job_DumpHostvarsJob
BECOME password: 

PLAY [127.0.0.1] ***************************************************************

TASK [ansible.builtin.debug] ***************************************************
 [started TASK: ansible.builtin.debug on 127.0.0.1]
ok: [127.0.0.1] => {
    "hostvars[inventory_hostname]": {
[... omitted ....]
        "ansible_vmenet2": {
            "device": "vmenet2",
            "flags": [
                "UP",
                "BROADCAST",
                "SMART",
                "RUNNING",
                "PROMISC",
                "SIMPLEX",
                "MULTICAST"
            ],
            "ipv4": [],
            "ipv6": [],
            "macaddress": "22:5c:be:40:1e:7d",
            "media": "Unknown",
            "media_select": "autoselect",
            "mtu": "1500",
            "status": "active",
            "type": "ether"
        },
        "discovered_interpreter_python": "/usr/bin/python3",
        "dummyHostVar": "dummyValue",
        "gather_subset": [
            "all"
        ],
        "group_names": [
            "main_hosts"
        ],
        "groups": {
            "all": [
                "127.0.0.1"
            ],
            "main_hosts": [
                "127.0.0.1"
            ],
            "ungrouped": []
        },
        "inventory_dir": "/Users/asullivan/backblaze/github_repos/boardwalk/test/server-client",
        "inventory_file": "/Users/asullivan/backblaze/github_repos/boardwalk/test/server-client/test-inventory",
        "inventory_hostname": "127.0.0.1",
        "inventory_hostname_short": "127.0.0.1",
        "module_setup": true,
        "omit": "__omit_place_holder__7ced53e29535c4ac518dd38767a1e0dd455538db",
        "playbook_dir": "/var/folders/q_/ns6q_l2j21zb_5k5qzlb3rq40000gq/T/tmp0ypmhclw/project"
    }
}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
2026-02-26 13:49:47.705 | INFO     | boardwalk.cli_run:execute_host_workflow:744 - 127.0.0.1: Updating remote state
2026-02-26 13:49:47.708 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:172 - 127.0.0.1: ansible_runner invocation: get_remote_state
2026-02-26 13:49:51.395 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:172 - 127.0.0.1: ansible_runner invocation: set_remote_state
2026-02-26 13:49:57.029 | SUCCESS  | boardwalk.cli_run:execute_host_workflow:761 - 127.0.0.1: Host completed successfully; wrapping up
2026-02-26 13:49:57.032 | INFO     | boardwalk.cli_run:update_host_facts_in_local_state:596 - 127.0.0.1: Updating Ansible facts in local state
2026-02-26 13:49:57.035 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:172 - 127.0.0.1: ansible_runner invocation: gather_facts
2026-02-26 13:49:59.712 | INFO     | boardwalk.cli_run:run_workflow:296 - 127.0.0.1: Release remote host lock
2026-02-26 13:49:59.716 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:172 - 127.0.0.1: ansible_runner invocation: release_remote_host
```

### Example run after the change

```
(boardwalk-py3.12) asullivan@MBP-NT9RPG2XV7 server-client % boardwalk workspace show
DumpHostvarsWorkspace
(boardwalk-py3.12) asullivan@MBP-NT9RPG2XV7 server-client % boardwalk version
0.8.26
(boardwalk-py3.12) asullivan@MBP-NT9RPG2XV7 server-client % boardwalk run                                
2026-02-26 14:00:55.775 | INFO     | boardwalk.cli_run:run:125 - Using workspace: DumpHostvarsWorkspace
2026-02-26 14:00:55.784 | INFO     | boardwalk.cli_run:filter_hosts_by_limit:375 - Reading inventory to process any --limit
2026-02-26 14:00:55.784 | INFO     | boardwalk.ansible:ansible_inventory:194 - Processing ansible-inventory
BECOME password: 
2026-02-26 14:01:01.048 | INFO     | boardwalk.cli_run:run_workflow:268 - 127.0.0.1: Workflow iteration on host 1 of 1
2026-02-26 14:01:01.065 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:174 - 127.0.0.1: ansible_runner invocation: check_remote_host_lock
2026-02-26 14:01:02.560 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:174 - 127.0.0.1: ansible_runner invocation: lock_remote_host
2026-02-26 14:01:06.702 | INFO     | boardwalk.cli_run:update_host_facts_in_local_state:596 - 127.0.0.1: Updating Ansible facts in local state
2026-02-26 14:01:06.706 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:174 - 127.0.0.1: ansible_runner invocation: gather_facts
2026-02-26 14:01:08.363 | INFO     | boardwalk.cli_run:execute_host_workflow:708 - 127.0.0.1: Updating remote state
2026-02-26 14:01:08.366 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:174 - 127.0.0.1: ansible_runner invocation: get_remote_state
2026-02-26 14:01:09.920 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:174 - 127.0.0.1: ansible_runner invocation: set_remote_state
2026-02-26 14:01:16.157 | INFO     | boardwalk.cli_run:execute_workflow_jobs:670 - 127.0.0.1: Running workflow main jobs
2026-02-26 14:01:16.165 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:174 - 127.0.0.1: ansible_runner invocation: main_TASK_Job_DumpHostvarsJob
BECOME password: 

PLAY [127.0.0.1] ***************************************************************

TASK [ansible.builtin.debug] ***************************************************
 [started TASK: ansible.builtin.debug on 127.0.0.1]
ok: [127.0.0.1] => {
    "hostvars[inventory_hostname]": {
[ ... omitted ... ]
        "ansible_vmenet2": {
            "device": "vmenet2",
            "flags": [
                "UP",
                "BROADCAST",
                "SMART",
                "RUNNING",
                "PROMISC",
                "SIMPLEX",
                "MULTICAST"
            ],
            "ipv4": [],
            "ipv6": [],
            "macaddress": "22:5c:be:40:1e:7d",
            "media": "Unknown",
            "media_select": "autoselect",
            "mtu": "1500",
            "status": "active",
            "type": "ether"
        },
        "boardwalk_operation": true,
        "discovered_interpreter_python": "/usr/bin/python3",
        "dummyHostVar": "dummyValue",
        "gather_subset": [
            "all"
        ],
        "group_names": [
            "main_hosts"
        ],
        "groups": {
            "all": [
                "127.0.0.1"
            ],
            "main_hosts": [
                "127.0.0.1"
            ],
            "ungrouped": []
        },
        "inventory_dir": "/Users/asullivan/backblaze/github_repos/boardwalk/test/server-client",
        "inventory_file": "/Users/asullivan/backblaze/github_repos/boardwalk/test/server-client/test-inventory",
        "inventory_hostname": "127.0.0.1",
        "inventory_hostname_short": "127.0.0.1",
        "module_setup": true,
        "omit": "__omit_place_holder__7f68169bb055c483ef3857d838668c40d96a30a1",
        "playbook_dir": "/var/folders/q_/ns6q_l2j21zb_5k5qzlb3rq40000gq/T/tmp541dczg3/project"
    }
}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
2026-02-26 14:01:16.795 | INFO     | boardwalk.cli_run:execute_host_workflow:744 - 127.0.0.1: Updating remote state
2026-02-26 14:01:16.801 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:174 - 127.0.0.1: ansible_runner invocation: get_remote_state
2026-02-26 14:01:18.400 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:174 - 127.0.0.1: ansible_runner invocation: set_remote_state
2026-02-26 14:01:25.402 | SUCCESS  | boardwalk.cli_run:execute_host_workflow:761 - 127.0.0.1: Host completed successfully; wrapping up
2026-02-26 14:01:25.407 | INFO     | boardwalk.cli_run:update_host_facts_in_local_state:596 - 127.0.0.1: Updating Ansible facts in local state
2026-02-26 14:01:25.410 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:174 - 127.0.0.1: ansible_runner invocation: gather_facts
2026-02-26 14:01:27.014 | INFO     | boardwalk.cli_run:run_workflow:296 - 127.0.0.1: Release remote host lock
2026-02-26 14:01:27.020 | INFO     | boardwalk.ansible:ansible_runner_run_tasks:174 - 127.0.0.1: ansible_runner invocation: release_remote_host
```

## Checklist
- [x] Have you updated the `version` in the `[project]` section of
the `pyproject.toml` file (if applicable)?
