### PR TITLE
feat: add --workspace-status-json to boardwalkd to generate JSON status for all workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 .pytest_cache/
 .ruff_cache/
+.ansible/
 .boardwalk/
 .boardwalkd/
 .DS_store

--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,14 @@ develop-server: develop
 ifdef BOARDWALKD_SLACK_WEBHOOK_URL
 	poetry run boardwalkd serve \
 		--develop \
+		--workspace-status-json \
 		--host-header-pattern="(localhost|127\.0\.0\.1)" \
 		--port=8888 \
 		--url='http://localhost:8888'
 else
 	poetry run boardwalkd serve \
 		--develop \
+		--workspace-status-json \
 		--host-header-pattern="(localhost|127\.0\.0\.1)" \
 		--port=8888 \
 		--url='http://localhost:8888'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 name = "boardwalk"
 description = "Boardwalk is a linear Ansible workflow engine"
 readme = "README.md"
-version = "0.8.27"
+version = "0.8.28"
 requires-python = ">=3.11,<4"
 authors = [
     {name="Mat Hornbeek", email="84995001+m4wh6k@users.noreply.github.com"},

--- a/src/boardwalkd/cli.py
+++ b/src/boardwalkd/cli.py
@@ -37,6 +37,18 @@ def cli():
     show_default=True,
 )
 @click.option(
+    "--service-token",
+    help=(
+        "A static API token for machine-to-machine integrations."
+        " When set, requests with this value in the boardwalk-api-token"
+        " header are authenticated without expiry as a service account."
+        " Generate with: openssl rand -hex 32"
+    ),
+    type=str,
+    default=None,
+    show_envvar=True,
+)
+@click.option(
     "--auth-method",
     help=(
         "Enables an authentication method for the web UI. The API always requires"
@@ -172,6 +184,7 @@ def cli():
 )
 def serve(
     auth_expire_days: float,
+    service_token: str | None,
     auth_method: str,
     develop: bool,
     host_header_pattern: str,
@@ -233,6 +246,7 @@ def serve(
             host_header_pattern=host_header_regex,
             owner=owner,
             port_number=port,
+            service_token=service_token,
             slack_app_token=slack_app_token,
             slack_bot_token=slack_bot_token,
             slack_error_webhook_url=slack_error_webhook_url,

--- a/src/boardwalkd/cli.py
+++ b/src/boardwalkd/cli.py
@@ -37,18 +37,6 @@ def cli():
     show_default=True,
 )
 @click.option(
-    "--service-token",
-    help=(
-        "A static API token for machine-to-machine integrations."
-        " When set, requests with this value in the boardwalk-api-token"
-        " header are authenticated without expiry as a service account."
-        " Generate with: openssl rand -hex 32"
-    ),
-    type=str,
-    default=None,
-    show_envvar=True,
-)
-@click.option(
     "--auth-method",
     help=(
         "Enables an authentication method for the web UI. The API always requires"
@@ -182,9 +170,15 @@ def cli():
     type=str,
     required=True,
 )
+@click.option(
+    "--workspace-status-json/--no-workspace-status-json",
+    help=("Exposed an unauthenticated JSON object of the status of all workspaces at /api/workspaces/status"),
+    type=bool,
+    default=False,
+    show_envvar=True,
+)
 def serve(
     auth_expire_days: float,
-    service_token: str | None,
     auth_method: str,
     develop: bool,
     host_header_pattern: str,
@@ -199,6 +193,7 @@ def serve(
     tls_key: str | None,
     tls_port: int | None,
     url: str,
+    workspace_status_json: bool,
 ):
     """Runs the server"""
     # Validate host_header_pattern
@@ -246,7 +241,6 @@ def serve(
             host_header_pattern=host_header_regex,
             owner=owner,
             port_number=port,
-            service_token=service_token,
             slack_app_token=slack_app_token,
             slack_bot_token=slack_bot_token,
             slack_error_webhook_url=slack_error_webhook_url,
@@ -256,6 +250,7 @@ def serve(
             tls_key_path=tls_key,
             tls_port_number=tls_port,
             url=url,
+            workspace_status_json=workspace_status_json,
         )
     )
 

--- a/src/boardwalkd/server.py
+++ b/src/boardwalkd/server.py
@@ -36,6 +36,7 @@ from boardwalk.utils import strtobool
 from boardwalkd.broadcast import handle_slack_broadcast
 from boardwalkd.protocol import ApiLoginMessage, WorkspaceDetails, WorkspaceEvent
 from boardwalkd.state import User, WorkspaceState, load_state, valid_user_roles
+from boardwalkd.utils import is_workspace_active
 
 module_dir = Path(__file__).resolve().parent
 state = load_state()
@@ -506,8 +507,6 @@ class APIBaseHandler(tornado.web.RequestHandler):
         # somehow they don't exist in the server state
         cur_user = self.current_user
         if isinstance(cur_user, bytes):
-            if getattr(self, "_is_service_auth", False):
-                return
             username = cur_user.decode()
             try:
                 if not state.users[username].enabled:
@@ -520,22 +519,10 @@ class APIBaseHandler(tornado.web.RequestHandler):
         pass
 
     def get_current_user(self) -> bytes | None:
-        """Decodes the API token to return the current logged in user.
-        If a service token is configured and matches, authenticates as a
-        service account without expiry."""
-        api_token = self.request.headers.get("boardwalk-api-token")
-        if not api_token:
-            return None
-
-        service_token = self.settings.get("service_token")
-        if service_token and api_token == service_token:
-            self._is_service_auth = True
-            return b"service@boardwalk"
-
-        self._is_service_auth = False
+        """Decodes the API token to return the current logged in user."""
         return self.get_secure_cookie(
             "boardwalk_api_token",
-            value=api_token,
+            value=self.request.headers.get("boardwalk-api-token"),
             max_age_days=self.settings["auth_expire_days"],
             min_version=2,
         )
@@ -628,21 +615,24 @@ class AuthApiDenied(APIBaseHandler):
 
 
 class WorkspacesStatusApiHandler(APIBaseHandler):
-    """Returns a read-only summary of all workspaces for monitoring integrations"""
+    """Returns an unauthenticated, read-only summary of all workspaces for monitoring integrations"""
 
-    @tornado.web.authenticated
+    # nosemgrep: test.boardwalk.python.security.handler-method-missing-authentication
     def get(self):
         result = []
         for name, ws in state.workspaces.items():
             entry: dict[str, Any] = {
                 "name": name,
-                "semaphores": ws.semaphores.dict(),
+                "semaphores": ws.semaphores.model_dump(),
             }
             if ws.details:
                 entry["details"] = {
                     "workflow": ws.details.workflow,
-                    "worker_hostname": ws.details.worker_hostname,
+                    "worker": f"{ws.details.worker_username}@{ws.details.worker_hostname}",
+                    "worker_connected": is_workspace_active(workspace_name=name),
                     "host_pattern": ws.details.host_pattern,
+                    "limit_pattern": "<unknown>" if ws.details.worker_limit == "" else ws.details.worker_limit,
+                    "command": ws.details.worker_command,
                 }
             if ws.last_seen:
                 entry["last_seen"] = ws.last_seen.isoformat()
@@ -851,10 +841,10 @@ def make_app(
     develop: bool,
     host_header_pattern: re.Pattern[str],
     owner: str,
-    service_token: str | None,
     slack_error_webhook_url: str,
     slack_webhook_url: str,
     url: str,
+    workspace_status_json: bool,
 ) -> tornado.web.Application:
     """Builds the tornado application object"""
     handlers: list[tornado.web.OutputTransform] = []
@@ -874,7 +864,7 @@ def make_app(
             "server_version": ui_method_server_version,
             "sort_events_by_date": ui_method_sort_events_by_date,
         },
-        "service_token": service_token,
+        "workspace_status_json": workspace_status_json,
         "url": urlparse(url),
         "websocket_ping_interval": 10,
         "xsrf_cookies": True,
@@ -989,7 +979,6 @@ async def run(
     host_header_pattern: re.Pattern[str],
     owner: str,
     port_number: int | None,
-    service_token: str | None,
     tls_crt_path: str | None,
     tls_key_path: str | None,
     slack_app_token: str | None,
@@ -999,6 +988,7 @@ async def run(
     slack_webhook_url: str,
     slack_slash_command_prefix: str,
     url: str,
+    workspace_status_json: bool,
 ):
     """Starts the tornado server and IO loop"""
     global state
@@ -1010,10 +1000,10 @@ async def run(
         develop=develop,
         host_header_pattern=host_header_pattern,
         owner=owner,
-        service_token=service_token,
         slack_error_webhook_url=slack_error_webhook_url,
         slack_webhook_url=slack_webhook_url,
         url=url,
+        workspace_status_json=workspace_status_json,
     )
 
     if port_number is not None:

--- a/src/boardwalkd/server.py
+++ b/src/boardwalkd/server.py
@@ -506,6 +506,8 @@ class APIBaseHandler(tornado.web.RequestHandler):
         # somehow they don't exist in the server state
         cur_user = self.current_user
         if isinstance(cur_user, bytes):
+            if getattr(self, "_is_service_auth", False):
+                return
             username = cur_user.decode()
             try:
                 if not state.users[username].enabled:
@@ -518,10 +520,22 @@ class APIBaseHandler(tornado.web.RequestHandler):
         pass
 
     def get_current_user(self) -> bytes | None:
-        """Decodes the API token to return the current logged in user"""
+        """Decodes the API token to return the current logged in user.
+        If a service token is configured and matches, authenticates as a
+        service account without expiry."""
+        api_token = self.request.headers.get("boardwalk-api-token")
+        if not api_token:
+            return None
+
+        service_token = self.settings.get("service_token")
+        if service_token and api_token == service_token:
+            self._is_service_auth = True
+            return b"service@boardwalk"
+
+        self._is_service_auth = False
         return self.get_secure_cookie(
             "boardwalk_api_token",
-            value=self.request.headers["boardwalk-api-token"],
+            value=api_token,
             max_age_days=self.settings["auth_expire_days"],
             min_version=2,
         )
@@ -611,6 +625,29 @@ class AuthApiDenied(APIBaseHandler):
     # nosemgrep: test.boardwalk.python.security.handler-method-missing-authentication
     def get(self):
         return self.send_error(403)
+
+
+class WorkspacesStatusApiHandler(APIBaseHandler):
+    """Returns a read-only summary of all workspaces for monitoring integrations"""
+
+    @tornado.web.authenticated
+    def get(self):
+        result = []
+        for name, ws in state.workspaces.items():
+            entry: dict[str, Any] = {
+                "name": name,
+                "semaphores": ws.semaphores.dict(),
+            }
+            if ws.details:
+                entry["details"] = {
+                    "workflow": ws.details.workflow,
+                    "worker_hostname": ws.details.worker_hostname,
+                    "host_pattern": ws.details.host_pattern,
+                }
+            if ws.last_seen:
+                entry["last_seen"] = ws.last_seen.isoformat()
+            result.append(entry)
+        self.write({"workspaces": result})
 
 
 class WorkspaceCatchApiHandler(APIBaseHandler):
@@ -814,6 +851,7 @@ def make_app(
     develop: bool,
     host_header_pattern: re.Pattern[str],
     owner: str,
+    service_token: str | None,
     slack_error_webhook_url: str,
     slack_webhook_url: str,
     url: str,
@@ -836,6 +874,7 @@ def make_app(
             "server_version": ui_method_server_version,
             "sort_events_by_date": ui_method_sort_events_by_date,
         },
+        "service_token": service_token,
         "url": urlparse(url),
         "websocket_ping_interval": 10,
         "xsrf_cookies": True,
@@ -902,6 +941,10 @@ def make_app(
                 AuthLoginApiWebsocketHandler,
             ),
             (
+                r"/api/workspaces/status",
+                WorkspacesStatusApiHandler,
+            ),
+            (
                 r"/api/workspace/(\w+)/details",
                 WorkspaceDetailsApiHandler,
             ),
@@ -946,6 +989,7 @@ async def run(
     host_header_pattern: re.Pattern[str],
     owner: str,
     port_number: int | None,
+    service_token: str | None,
     tls_crt_path: str | None,
     tls_key_path: str | None,
     slack_app_token: str | None,
@@ -966,6 +1010,7 @@ async def run(
         develop=develop,
         host_header_pattern=host_header_pattern,
         owner=owner,
+        service_token=service_token,
         slack_error_webhook_url=slack_error_webhook_url,
         slack_webhook_url=slack_webhook_url,
         url=url,

--- a/src/boardwalkd/slack.py
+++ b/src/boardwalkd/slack.py
@@ -39,42 +39,9 @@ from boardwalk.app_exceptions import BoardwalkException
 from boardwalkd.protocol import WorkspaceEvent
 from boardwalkd.server import SERVER_URL, SLACK_SLASH_COMMAND_PREFIX, SLACK_TOKENS, internal_workspace_event
 from boardwalkd.server import state as STATE
+from boardwalkd.utils import count_of_workspaces_caught, list_active_workspaces, list_inactive_workspaces
 
 app = AsyncApp(token=SLACK_TOKENS.get("bot"))
-
-
-# Possibly move this elsewhere if these functions are useful in other locations?
-def _count_of_workspaces_caught() -> int:
-    """
-    Returns the number of workspaces which are caught
-    """
-    return len([k for k, v in STATE.workspaces.items() if v.semaphores.caught])
-
-
-def _list_active_workspaces(last_seen_seconds: int = 10, _sorted: bool = True) -> list[str]:
-    """
-    Returns a sorted list[str] of currently active workspaces. Takes
-    `last_seen_seconds`, which corresponds to how long ago the worker connected
-    to the workspace was last seen. Defaults to 10.
-    """
-    workspaces: list[str] = []
-    for name, workspace in STATE.workspaces.items():
-        if (datetime.now(UTC) - workspace.last_seen.replace(tzinfo=UTC)).total_seconds() < last_seen_seconds:  # type: ignore
-            workspaces.append(name)
-    if _sorted:
-        return sorted(workspaces)
-    else:
-        return workspaces
-
-
-def _list_inactive_workspaces(last_seen_seconds: int = 10) -> list[str]:
-    """
-    Returns a sorted list[str] of inactive workspaces. Takes
-    `last_seen_seconds`, which corresponds to the time at which the last
-    connected worker was seen before the workspace is considered inactive.
-    Defaults to 10.
-    """
-    return sorted([name for name in STATE.workspaces.keys() if name not in _list_active_workspaces(last_seen_seconds)])
 
 
 @app.command(f"/{SLACK_SLASH_COMMAND_PREFIX}-version")
@@ -273,7 +240,7 @@ async def command_list_active_workspaces(ack: AsyncAck, body: dict[str, Any], cl
     message_blocks = [
         SectionBlock(text=MarkdownTextObject(text="The following workspaces have an active worker connected:"))
     ]
-    active_workspaces = _list_active_workspaces()
+    active_workspaces = list_active_workspaces()
 
     if len(active_workspaces) > 0:
         message_blocks.append(SectionBlock(text=MarkdownTextObject(text=", ".join(active_workspaces))))
@@ -341,8 +308,8 @@ async def app_home_opened(ack: AsyncAck, client: AsyncWebClient, logger: Logger,
         SectionBlock(
             text=" ".join(  # semgrep avoidance https://sg.run/Kl07 -- string-concat-in-list
                 [
-                    f"There are {len(STATE.workspaces)} workspaces in total, of which {_count_of_workspaces_caught()} are",
-                    f"caught, with {len(_list_active_workspaces())} active CLI workers.",
+                    f"There are {len(STATE.workspaces)} workspaces in total, of which {count_of_workspaces_caught()} are",
+                    f"caught, with {len(list_active_workspaces())} active CLI workers.",
                 ]
             )
         ),
@@ -351,7 +318,7 @@ async def app_home_opened(ack: AsyncAck, client: AsyncWebClient, logger: Logger,
 
     _active: list[str] = []
     _inactive: list[str] = []
-    for _list, _workspaces in [(_active, _list_active_workspaces()), (_inactive, _list_inactive_workspaces())]:
+    for _list, _workspaces in [(_active, list_active_workspaces()), (_inactive, list_inactive_workspaces())]:
         for _workspace in _workspaces:
             _list.append(
                 f"{'🕵️‍♀️' if STATE.workspaces[_workspace].details.worker_command == 'check' else '👟'}"

--- a/src/boardwalkd/utils.py
+++ b/src/boardwalkd/utils.py
@@ -1,0 +1,46 @@
+from datetime import UTC, datetime
+
+from boardwalkd import server
+
+
+def list_active_workspaces(last_seen_seconds: int = 10, _sorted: bool = True) -> list[str]:
+    """
+    Returns a sorted list[str] of currently active workspaces. Takes
+    `last_seen_seconds`, which corresponds to how long ago the worker connected
+    to the workspace was last seen. Defaults to 10.
+    """
+    workspaces: list[str] = []
+    for name, workspace in server.state.workspaces.items():
+        if (datetime.now(UTC) - workspace.last_seen.replace(tzinfo=UTC)).total_seconds() < last_seen_seconds:  # type: ignore
+            workspaces.append(name)
+    if _sorted:
+        return sorted(workspaces)
+    else:
+        return workspaces
+
+
+def is_workspace_active(workspace_name: str, last_seen_seconds: int = 10) -> bool:
+    """Returns Boolean True if the provided workspace name is active, based on the configured `last_seen_seconds` value."""
+    if ws := server.state.workspaces.get(workspace_name):
+        if (datetime.now(UTC) - ws.last_seen.replace(tzinfo=UTC)).total_seconds() < last_seen_seconds:  # type: ignore
+            return True
+    return False
+
+
+def list_inactive_workspaces(last_seen_seconds: int = 10) -> list[str]:
+    """
+    Returns a sorted list[str] of inactive workspaces. Takes
+    `last_seen_seconds`, which corresponds to the time at which the last
+    connected worker was seen before the workspace is considered inactive.
+    Defaults to 10.
+    """
+    return sorted(
+        [name for name in server.state.workspaces.keys() if name not in list_active_workspaces(last_seen_seconds)]
+    )
+
+
+def count_of_workspaces_caught() -> int:
+    """
+    Returns the number of workspaces which are caught
+    """
+    return len([k for k, v in server.state.workspaces.items() if v.semaphores.caught])


### PR DESCRIPTION
## What and why?
Adds a boardwalkd flag `--workspace-status-json` to enable the route
/api/workspaces/status to provide a JSON object containing the status
for all known workspaces.

This could, for example, feed into a secondary monitoring system, allowing
the status of Boardwalk to be centrally monitored by a NOC team, for
example.

## How was this tested?
The full `make test` suite passes, and verified that `http://localhost:8888/api/workspaces/status` produced the desired result.

<img width="1829" height="1012" alt="Example of --workspace-status-json behavior" src="https://github.com/user-attachments/assets/b6485ad0-eae4-4f1b-98cd-db6dcc65d2f1" />

## Checklist
- [x] Have you updated the `version` in the `[project]` section of
the `pyproject.toml` file (if applicable)?
