### PR TITLE
bug: add missing setting check for workspace_status_json on route

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 name = "boardwalk"
 description = "Boardwalk is a linear Ansible workflow engine"
 readme = "README.md"
-version = "0.8.28"
+version = "0.8.29"
 requires-python = ">=3.11,<4"
 authors = [
     {name="Mat Hornbeek", email="84995001+m4wh6k@users.noreply.github.com"},

--- a/src/boardwalkd/server.py
+++ b/src/boardwalkd/server.py
@@ -619,6 +619,9 @@ class WorkspacesStatusApiHandler(APIBaseHandler):
 
     # nosemgrep: test.boardwalk.python.security.handler-method-missing-authentication
     def get(self):
+        if not self.settings.get("workspace_status_json"):
+            return self.send_error(404)
+
         result = []
         for name, ws in state.workspaces.items():
             entry: dict[str, Any] = {


### PR DESCRIPTION
## What and why?
The route for `/api/workspaces/status` was found to be missing the corresponding check within the route to only display information if the `boardwalkd` option was set.

## How was this tested?
Alternating between the version of serving the app with and without `--workspace-status-json`:
```
(boardwalk-py3.12) asullivan@MBP-NT9RPG2XV7 boardwalk % poetry run boardwalkd serve \
                --develop \
                                --host-header-pattern="(localhost|127\.0\.0\.1)" \
                --port=8888 \
                --url='http://localhost:8888'
404 GET /api/workspaces/status (127.0.0.1) 1.61ms
^C
Aborted!
(boardwalk-py3.12) asullivan@MBP-NT9RPG2XV7 boardwalk % make develop-server 
poetry install
Installing dependencies from lock file

No dependencies to install or update

Installing the current project: boardwalk (0.8.28)
poetry run boardwalkd serve \
		--develop \
		--workspace-status-json \
		--host-header-pattern="(localhost|127\.0\.0\.1)" \
		--port=8888 \
		--url='http://localhost:8888'
404 GET /favicon.ico (127.0.0.1) 3.84ms
^C
Aborted!
make: *** [develop-server] Error 1
```

## Checklist
- [x] Have you updated the `version` in the `[project]` section of
the `pyproject.toml` file (if applicable)?
