### PR TITLE
boardwalk/boardwalkd: miscellaneous enhancements, bugfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Set default build options
+PYTEST_BOARDWALKD_PERSIST_WORKSPACES_BETWEEN_TESTS ?= False
+
 # Builds module artifacts
 .PHONY: build
 build: dist
@@ -59,7 +62,7 @@ dist: clean
 # Builds the Sphinx HTML documentation -- Shortcut for `cd docs && make html`
 .PHONY: docs
 docs: develop
-	poetry install --with=docs --sync
+	poetry sync --with=docs
 	poetry run make --directory=./docs/ html
 
 # Applies fixable errors, and formats code
@@ -108,6 +111,12 @@ ifndef CI
 else
 	poetry run pytest
 endif
+
+# Same as `test-pytest`, but does not clear the boardwalkd server state between
+# test runs (so the workspace state can be inspected after execution)
+.PHONY: test-pytest-keep-workspace-state
+test-pytest-keep-workspace-state: develop
+	PYTEST_BOARDWALKD_PERSIST_WORKSPACES_BETWEEN_TESTS=True poetry run pytest  --verbose
 
 # Run all available Ruff checks
 .PHONY: test-ruff

--- a/src/boardwalk/cli.py
+++ b/src/boardwalk/cli.py
@@ -72,6 +72,7 @@ def cli(ctx: click.Context, verbose: int):
 
     loglevel = "INFO" if verbose == 0 else "DEBUG" if verbose == 1 else "TRACE"
     ctx.obj["VERBOSITY"] = verbose
+    ctx.auto_envvar_prefix = "BOARDWALK"
     logger.remove()
     logger.add(sys.stdout, level=loglevel)
     if verbose > 0:
@@ -87,6 +88,9 @@ def cli(ctx: click.Context, verbose: int):
         # exit if it's missing. The version subcommand is the only one that
         # doesn't need a Boardwalkfile.py
         if ctx.invoked_subcommand == "version":
+            return
+        elif "--help" in sys.argv:
+            # Allow any invocation with the `--help` flag in the argv to succeed, even without a Boardwalkfile.py
             return
         click.echo(cli.get_help(ctx))
         raise BoardwalkException("No Boardwalkfile.py found")

--- a/src/boardwalk/cli_run.py
+++ b/src/boardwalk/cli_run.py
@@ -125,6 +125,9 @@ def run(
     global _stomp_locks
     _stomp_locks = stomp_locks
 
+    ctx.ensure_object(dict)
+    ctx.obj["OPEN_BROWSER_FOR_API_LOGIN"] = open_browser_for_api_login
+
     try:
         ws = get_ws()
     except NoActiveWorkspace as e:
@@ -729,7 +732,7 @@ def directly_confirm_host_preconditions(host: Host, inventory_vars: InventoryHos
         boardwalkd_client.queue_event(
             WorkspaceEvent(
                 severity="info",
-                message=f"{host.name}:  Checking Job preconditions on host",
+                message=f"{host.name}: Checking Job preconditions on host",
             ),
         )
     update_host_facts_in_local_state(host, workspace)
@@ -759,7 +762,7 @@ def directly_confirm_host_preconditions(host: Host, inventory_vars: InventoryHos
         boardwalkd_client.queue_event(
             WorkspaceEvent(
                 severity="info",
-                message=f"{host.name}:  Host didn't meet job preconditions",
+                message=f"{host.name}: Host didn't meet job preconditions",
             ),
         )
 

--- a/src/boardwalkd/cli.py
+++ b/src/boardwalkd/cli.py
@@ -26,7 +26,7 @@ def cli():
     Boardwalkd is the server component of Boardwalk.
     See the README.md @ https://github.com/Backblaze/boardwalk for more info
 
-    To see more info about any subcommand, do `boardwalkd <subcommand> --help`
+    To see more info about any subcommand, execute `boardwalkd <subcommand> --help`
     """
     pass
 
@@ -226,7 +226,7 @@ def serve(
     verbose: int,
     workspace_status_json: bool,
 ):
-    """Runs the server"""
+    """Runs the `boardwalkd` server until terminated"""
     logger.enable("boardwalkd")
     logger.remove()
     loglevel = "INFO" if verbose == 0 else "DEBUG" if verbose == 1 else "TRACE"
@@ -280,8 +280,11 @@ def serve(
     except SlackErrorAdviceConfigError as e:
         raise BoardwalkException(str(e))
 
-    asyncio.run(
-        run(
+    # This pattern lets us keep the actual `run()` function able to be called by
+    # pytest without blocking the main thread. Here, we're fine with it, cause
+    # this command spawns and runs the server via the CLI
+    async def start_server_and_wait():
+        await run(
             auth_expire_days=auth_expire_days,
             auth_login_slack_notify=auth_login_slack_notify,
             auth_method=auth_method,
@@ -301,7 +304,10 @@ def serve(
             url=url,
             workspace_status_json=workspace_status_json,
         )
-    )
+        await asyncio.Event().wait()
+
+    # Spawn the server and run until terminated
+    asyncio.run(start_server_and_wait())
 
 
 @cli.command(

--- a/src/boardwalkd/protocol.py
+++ b/src/boardwalkd/protocol.py
@@ -172,7 +172,7 @@ class Client:
             if msg.login_url:
                 click_context = click.get_current_context()
                 print(f"---\nPlease visit to login:\n{msg.login_url}")
-                if click_context.params.get("open_browser_for_api_login") and webbrowser.open_new_tab(msg.login_url):
+                if click_context.obj.get("OPEN_BROWSER_FOR_API_LOGIN", True) and webbrowser.open_new_tab(msg.login_url):
                     print("---\nOpened browser to login URL")
             elif msg.token:
                 conn.close()
@@ -260,7 +260,7 @@ class Client:
                 raise e
 
         details = WorkspaceDetails()
-        return details.parse_raw(request.body)
+        return details.model_validate_json(request.body)
 
     def workspace_post_catch(self, workspace_name: str):
         """Posts a catch to the server"""

--- a/src/boardwalkd/server.py
+++ b/src/boardwalkd/server.py
@@ -18,7 +18,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from importlib.metadata import version as lib_version
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import ParseResult, urljoin, urlparse
 
 import tornado.auth
@@ -46,6 +46,9 @@ from boardwalkd.protocol import AUTH_LOGIN_CONTEXT_FIELDS, ApiLoginMessage, Work
 from boardwalkd.slack_error_advice import SlackErrorAdviceRule, matching_error_advice
 from boardwalkd.state import User, WorkspaceState, load_state, valid_user_roles
 from boardwalkd.utils import is_workspace_active
+
+if TYPE_CHECKING:
+    from tornado.httpserver import HTTPServer
 
 module_dir = Path(__file__).resolve().parent
 state = load_state()
@@ -659,7 +662,15 @@ class AuthLoginApiHandler(UIBaseHandler):
         except AuthLoginApiWebsocketIDNotFound:
             return self.send_error(404)
 
-        return self.write("Authentication successful. You may close this window")
+        return self.write("""
+            Authentication to Boardwalk's API was successful. You may close this
+            window if it does not automatically close.
+            <script>
+            setTimeout(function() {
+                window.close()
+            }, 1000);
+            </script>
+        """)
 
 
 class AuthLoginApiWebsocketHandler(tornado.websocket.WebSocketHandler):
@@ -749,6 +760,7 @@ class DevelopmentClearAllWorkspaces(APIBaseHandler):
                     continue
                 del state.workspaces[name]
             state.flush()
+            return
         else:
             return self.send_error(403)
 
@@ -761,6 +773,7 @@ class WorkspacesStatusApiHandler(APIBaseHandler):
         if not self.settings.get("workspace_status_json"):
             return self.send_error(404)
 
+        payload: dict[str, Any] = {"boardwalkd_version": lib_version("boardwalk")}
         result = []
         for name, ws in state.workspaces.items():
             entry: dict[str, Any] = {
@@ -774,7 +787,8 @@ class WorkspacesStatusApiHandler(APIBaseHandler):
             if ws.last_seen:
                 entry["last_seen"] = ws.last_seen.isoformat()
             result.append(entry)
-        self.write({"workspaces": result})
+        payload["workspaces"] = result
+        self.write(payload)
 
 
 class WorkspaceCatchApiHandler(APIBaseHandler):
@@ -1218,7 +1232,7 @@ async def run(
     slack_slash_command_prefix: str,
     url: str,
     workspace_status_json: bool,
-):
+) -> tuple[tornado.web.Application, list[HTTPServer]]:
     """Starts the tornado server and IO loop"""
     global state
     global SLACK_SLASH_COMMAND_PREFIX
@@ -1238,8 +1252,9 @@ async def run(
         workspace_status_json=workspace_status_json,
     )
 
+    http_servers: list[HTTPServer] = []
     if port_number is not None:
-        app.listen(port_number)
+        http_servers.append(app.listen(port_number))
         # If port_number=0 a random open port will be selected and the log message
         # will not be accurate
         app_log.info(f"Server listening on non-TLS port: {port_number}")
@@ -1251,7 +1266,7 @@ async def run(
         ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
         ssl_ctx.load_cert_chain(certfile=tls_crt_path, keyfile=tls_key_path)  # type: ignore
 
-        app.listen(tls_port_number, ssl_options=ssl_ctx)
+        http_servers.append(app.listen(tls_port_number, ssl_options=ssl_ctx))
         # If tls_port_number=0 a random open port will be selected and the log
         # message will not be accurate
         app_log.info(f"Server listening on TLS port: {tls_port_number}")
@@ -1277,4 +1292,4 @@ async def run(
 
         await slack.connect()  # pyright: ignore[reportAttributeAccessIssue]
 
-    await asyncio.Event().wait()
+    return (app, http_servers)

--- a/src/boardwalkd/state.py
+++ b/src/boardwalkd/state.py
@@ -71,7 +71,7 @@ class State(StateBaseModel):
         Some items are excluded because they should only be set during runtime
         """
         # Write state to disk.
-        statefile_path.write_text(self.json())
+        statefile_path.write_text(self.model_dump_json())
 
 
 def load_state() -> State:

--- a/test/boardwalkd/test_api.py
+++ b/test/boardwalkd/test_api.py
@@ -1,0 +1,26 @@
+import os
+from importlib.metadata import version as lib_version
+from typing import Any
+
+import pytest
+import requests
+from anyio import to_thread
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(
+    condition=os.environ.get("PYTEST_BOARDWALKD_PERSIST_WORKSPACES_BETWEEN_TESTS", "False") == "True",
+    reason="Envvar PYTEST_BOARDWALKD_PERSIST_WORKSPACES_BETWEEN_TESTS is set True",
+)
+@pytest.mark.usefixtures("ensure_workspaces_cleared")
+async def test_api_workspaces_status_result_when_no_workspaces_active(
+    spawn_boardwalkd_server_and_maybe_clear_workspaces,
+):
+    expected_payload: dict[str, Any] = {
+        "boardwalkd_version": lib_version("boardwalk"),
+        "workspaces": [],
+    }
+    resp = await to_thread.run_sync(
+        requests.get, f"{spawn_boardwalkd_server_and_maybe_clear_workspaces}/api/workspaces/status"
+    )
+    assert resp.json() == expected_payload

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,21 +1,93 @@
+import asyncio
 import os
+import re
 import shutil
 import tempfile
 from getpass import getpass
 
 import pytest
-import requests
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
 # The default Boardwalkd url for testing via a pytest harness
-boardwalkd_url = "http://localhost:8888"
+boardwalkd_standard_dev_port = 8888
+boardwalkd_url = "http://localhost:{port}"
 
 
-@pytest.fixture(scope="session", autouse=True)
-def clear_workspaces_before_running_tests():
-    """Fixture to clear the boardwalkd workspace state before execution of the pytest run."""
-    if not os.environ.get("CI"):
-        requests.post(url=boardwalkd_url + "/develop/clear_all_workspaces", timeout=2)
-    yield
+@pytest.fixture(scope="function")
+async def spawn_boardwalkd_server(anyio_backend, free_tcp_port: int):
+    """Spawns a `boardwalkd` server if one is not currently running.
+
+    If one is spawned, a free port is selected and the Boardwalkfile.py
+    will use the selected port."""
+    try:
+        http_client = AsyncHTTPClient()
+        url = boardwalkd_url.format(port=boardwalkd_standard_dev_port)
+        await http_client.fetch(url, raise_error=False)
+        print(f"Using existing boardwalkd instance @ {url}")
+        yield url
+        return
+    except ConnectionRefusedError:
+        # If we hit a connection error, no server is up; so let's launch our own below
+        from boardwalkd.server import run as boardwalkd_run
+
+        os.environ["BOARDWALK_PYTEST_PORT"] = str(free_tcp_port)
+        url = boardwalkd_url.format(port=free_tcp_port)
+        run_kwargs = {
+            "auth_expire_days": 3,
+            "auth_login_slack_notify": False,
+            "auth_method": "anonymous",
+            "develop": True,
+            "host_header_pattern": re.compile(r"(localhost|127\.0\.0\.1)"),
+            "owner": "anonymous@example.com",
+            "port_number": free_tcp_port,
+            "tls_crt_path": None,
+            "tls_key_path": None,
+            "slack_app_token": None,
+            "slack_bot_token": None,
+            "slack_error_advice_rules": [],
+            "tls_port_number": None,
+            "slack_error_webhook_url": "",
+            "slack_webhook_url": "",
+            "slack_slash_command_prefix": "brdwlk",
+            "url": url,
+            "workspace_status_json": True,
+        }
+        app, http_servers = await boardwalkd_run(**run_kwargs)
+
+        await asyncio.sleep(0.5)
+
+        # Yield to the next text and/or fixture, and return the url
+        yield url
+
+        # Close out all the server connections
+        for server in http_servers:
+            server.stop()
+            await server.close_all_connections()
+
+
+@pytest.fixture(scope="function")
+async def ensure_workspaces_cleared(spawn_boardwalkd_server):
+    """Ensures an instance of `boardwalkd` is running, and clears all workspaces in the state."""
+    http_client = AsyncHTTPClient()
+    await http_client.fetch(
+        HTTPRequest(url=spawn_boardwalkd_server + "/develop/clear_all_workspaces", method="POST", body="{}")
+    )
+
+
+@pytest.fixture(scope="function")
+async def spawn_boardwalkd_server_and_maybe_clear_workspaces(spawn_boardwalkd_server):
+    """Ensures an instance of `boardwalkd` is running, and conditionally clears all workspaces in the state,
+    if the envvar `PYTEST_BOARDWALKD_PERSIST_WORKSPACES_BETWEEN_TESTS` is set."""
+    if os.environ.get("PYTEST_BOARDWALKD_PERSIST_WORKSPACES_BETWEEN_TESTS", "False") != "True":
+        http_client = AsyncHTTPClient()
+        await http_client.fetch(
+            HTTPRequest(
+                url=spawn_boardwalkd_server + "/develop/clear_all_workspaces",
+                method="POST",
+                allow_nonstandard_methods=True,
+            )
+        )
+    yield spawn_boardwalkd_server
 
 
 @pytest.fixture(scope="package")

--- a/test/integration/test_workspaces.py
+++ b/test/integration/test_workspaces.py
@@ -2,6 +2,7 @@ import os
 import platform
 import re
 import signal
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -17,11 +18,13 @@ async def execute_boardwalk_workspace_test(
     get_become_password_file_path: Path,
     use_isolated_boardwalk_directory,
 ):
+    # API_LOGIN_URI_REGEX = re.compile(r"http://localhost:\d{1,5}/api/auth/login\?id=[a-z0-9]{16}")
     WORKSPACE_CAUGHT_REGEX = re.compile(
         rf"The {workspace_name} workspace is remotely caught on .+ Waiting for release before continuing"
     )
     envvars: dict[str, Any] = {
         "ANSIBLE_BECOME_PASSWORD_FILE": get_become_password_file_path,
+        # "BOARDWALK_RUN_OPEN_BROWSER_FOR_API_LOGIN": "False",
         "BOARDWALK_VERBOSITY": "2",
     }
     new_environ = os.environ | envvars
@@ -32,21 +35,22 @@ async def execute_boardwalk_workspace_test(
         "boardwalk run",
     )
     output_stdout = []
-    output_stderr = []
     os.chdir(use_isolated_boardwalk_directory)
     async with create_task_group():
         for command in commands:
             with fail_after(delay=90) as scope:
-                async with await open_process(command=command, env=new_environ) as process:
+                async with await open_process(command=command, env=new_environ, stderr=subprocess.STDOUT) as process:
                     async for text in TextReceiveStream(process.stdout):  # type:ignore
                         # To allow for reading what was received, if the test ends up failing.
-                        print(text)
+                        print(text, end="")
                         output_stdout.append(text)
+                        # TODO: Figure out how to get async API login working?
+                        # Or should we just have a flag to optionally disable
+                        # API authentication if (and only if) in development
+                        # mode altogether?
+                        # if match := re.search(API_LOGIN_URI_REGEX, text):
                         if re.search(WORKSPACE_CAUGHT_REGEX, text):
                             process.send_signal(signal.SIGINT)
-                    async for text in TextReceiveStream(process.stderr):  # type:ignore
-                        print(text)
-                        output_stderr.append(text)
         assert not scope.cancelled_caught
 
     if failure_expected:
@@ -98,6 +102,7 @@ async def execute_boardwalk_workspace_test(
         ),
     ],
 )
+@pytest.mark.usefixtures("spawn_boardwalkd_server_and_maybe_clear_workspaces")
 async def test_development_workspaces(
     workspace_name: str,
     failure_expected: bool,
@@ -115,6 +120,7 @@ async def test_development_workspaces(
 
 
 @pytest.mark.anyio
+@pytest.mark.usefixtures("spawn_boardwalkd_server_and_maybe_clear_workspaces")
 @pytest.mark.skipif(condition="CI" in os.environ, reason="Not yet able to execute non-interactively.")
 async def test_ensure_remote_workflow_success_state_false_during_workflow_execution(
     get_become_password_file_path: Path,

--- a/test/server-client/Boardwalkfile.py
+++ b/test/server-client/Boardwalkfile.py
@@ -11,7 +11,8 @@ from boardwalk import PlaybookJob, TaskJob, Workflow, Workspace, WorkspaceConfig
 if TYPE_CHECKING:
     from boardwalk import AnsibleTasksType
 
-boardwalkd_url = "http://localhost:8888/"
+port = os.environ.get("BOARDWALK_PYTEST_PORT", "8888")
+boardwalkd_url = f"http://localhost:{port}/"
 
 # Ansible checks the envvar first for configuration; so override the location with one
 # we control so tests work.


### PR DESCRIPTION
## What and why?

### `boardwalk`
- boardwalk (enh): Configures the Click `auto_envvar_prefix` of `BOARDWALK` (though right now we aren't showing them in `--help`, but they are visible).
- boardwalk (enh): Improves the user experience around `boardwalk` API authentication, wherein the `/api/auth/login` page. Previously the page just remained open, and required the user to close it. A small Javascript snippet was added to attempt to close the new tab after one second.
- boardwalk (bug): Fixes a bug where invoking commands with `--help` would fail if no `Boardwalkfile.py` was present in the current working directory.

### `boardwalkd`
- boardwalkd (tweak): The returned JSON blob from `/api/workspaces/status` now also includes a value for the `boardwalkd_version`.

### Changes to development-specific items
- development: Running pytest will now check if an existing development instance -- as launched using the settings in `make develop-server` -- is running; if it is not found, pytest will launch a per-function instance of `boardwalkd` on a random free port (and configure the test `Boardwalkfile.py` with the port which pytest selected). Thus, running `make develop-server` is no longer a prerequisite to `make test`.
- development: Running a pytest session will clear the `boardwalkd` workspace state by default. This ensures that any workspaces which are caught and/or mutexed will not cause a pytest invocation to fail. Use `make test-pytest-keep-workspace-state` -- or call `pytest` with the envvar `PYTEST_BOARDWALKD_PERSIST_WORKSPACES_BETWEEN_TESTS=True` set -- to persist workspaces after the run.

Internal reference: OPSYSENG-1732

## How was this tested?

`make test`; all tests passed.

## Checklist
- [n/a] Have you updated the `version` in the `[project]` section of
the `pyproject.toml` file (if applicable)?
-> Not bumping; will be batched into a forthcoming release.