### PR TITLE
[SREE-3243] Refresh boardwalkd dashboard UI

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -2,5 +2,3 @@
   public domain image from
   [Ingolfson](https://commons.wikimedia.org/wiki/User:Ingolfson) on [Wikimedia
   Commons](https://commons.wikimedia.org/wiki/File:Swampy_But_Pretty_Bog_In_Fiordland_NZ.jpg)
-- GitHub Corner code in `src/boardwalkd/templates/base.html` - MIT licensed,
-  from [tholman/github-corners](https://github.com/tholman/github-corners)

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,6 @@ develop-server: develop
 ifdef BOARDWALKD_SLACK_WEBHOOK_URL
 	poetry run boardwalkd serve \
 		--develop \
-		--demo \
 		--workspace-status-json \
 		--host-header-pattern="(localhost|127\.0\.0\.1)" \
 		--port=8888 \
@@ -50,13 +49,20 @@ ifdef BOARDWALKD_SLACK_WEBHOOK_URL
 else
 	poetry run boardwalkd serve \
 		--develop \
-		--demo \
 		--workspace-status-json \
 		--host-header-pattern="(localhost|127\.0\.0\.1)" \
 		--port=8888 \
 		--url='http://localhost:8888' \
 		--workspace-status-json
 endif
+
+# Also runs the server, but loads demo data for UI testing
+.PHONY: develop-server-demo
+develop-server-demo:
+	@echo '[.] Resetting .boardwalkd state ...'
+	find . -type d -name '.boardwalkd' | xargs rm -rf
+	@echo '[.] Launching boardwalkd with demo data loaded ...'
+	BOARDWALKD_DEMO=True $(MAKE) develop-server
 
 dist: clean
 	poetry build

--- a/Makefile
+++ b/Makefile
@@ -44,16 +44,14 @@ ifdef BOARDWALKD_SLACK_WEBHOOK_URL
 		--host-header-pattern="(localhost|127\.0\.0\.1)" \
 		--port=8888 \
 		--url='http://localhost:8888' \
-		--slack-error-advice-config test/server-client/slack-error-advice.toml \
-		--workspace-status-json
+		--slack-error-advice-config test/server-client/slack-error-advice.toml
 else
 	poetry run boardwalkd serve \
 		--develop \
 		--workspace-status-json \
 		--host-header-pattern="(localhost|127\.0\.0\.1)" \
 		--port=8888 \
-		--url='http://localhost:8888' \
-		--workspace-status-json
+		--url='http://localhost:8888'
 endif
 
 # Also runs the server, but loads demo data for UI testing

--- a/Makefile
+++ b/Makefile
@@ -40,15 +40,17 @@ develop-server: develop
 ifdef BOARDWALKD_SLACK_WEBHOOK_URL
 	poetry run boardwalkd serve \
 		--develop \
+		--demo \
 		--workspace-status-json \
 		--host-header-pattern="(localhost|127\.0\.0\.1)" \
 		--port=8888 \
 		--url='http://localhost:8888' \
-		--slack-error-advice-config test/server-client/slack-error-advice.toml
+		--slack-error-advice-config test/server-client/slack-error-advice.toml \
 		--workspace-status-json
 else
 	poetry run boardwalkd serve \
 		--develop \
+		--demo \
 		--workspace-status-json \
 		--host-header-pattern="(localhost|127\.0\.0\.1)" \
 		--port=8888 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,9 @@ packages = [
 include = [
     { path = "py.typed" },
     { path = "static/*.css" },
-    { path = "static/*.js"},
-    { path = "templates/*.html"}
+    { path = "static/*.js" },
+    { path = "static/*.svg" },
+    { path = "templates/*.html" }
 ]
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 name = "boardwalk"
 description = "Boardwalk is a linear Ansible workflow engine"
 readme = "README.md"
-version = "0.9.0"
+version = "0.9.1"
 requires-python = ">=3.11,<4"
 authors = [
     {name="Mat Hornbeek", email="84995001+m4wh6k@users.noreply.github.com"},

--- a/src/boardwalk/ansible.py
+++ b/src/boardwalk/ansible.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import json
 import sys
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
         playbook: RunnerPlaybook | AnsibleTasksType
         verbosity: int
         extravars: dict[str, Any] | None
+        event_handler: Callable[[dict[str, Any]], bool]
 
     class RunnerKwargsEnvvars(TypedDict, total=False):
         ANSIBLE_BECOME_ASK_PASS: str
@@ -171,6 +172,7 @@ def ansible_runner_run_tasks(
     timeout: int | None = None,
     verbosity: int = 0,
     extra_vars: dict = {},
+    event_handler: Callable[[dict[str, Any]], bool] | None = None,
 ) -> ansible_runner.Runner:
     """
     Wraps ansible_runner.run to run Ansible tasks with some defaults for
@@ -199,6 +201,8 @@ def ansible_runner_run_tasks(
         runner_kwargs["limit"] = limit
     if timeout:
         runner_kwargs["envvars"]["ANSIBLE_TASK_TIMEOUT"] = str(timeout)
+    if event_handler:
+        runner_kwargs["event_handler"] = event_handler
 
     logger.trace(f"Constructing runner_kwargs for job type {job_type.name}")
     if job_type == boardwalk.manifest.JobTypes.TASK:

--- a/src/boardwalk/cli_run.py
+++ b/src/boardwalk/cli_run.py
@@ -279,6 +279,7 @@ def run_workflow(
         host = hosts[i]
 
         if boardwalkd_client:
+            # Update the server's workspace state so the UI reflects the current host.
             boardwalkd_client.post_details(
                 build_workspace_details(
                     workspace=workspace,
@@ -643,7 +644,12 @@ def resolve_workspace_ui_group(
     current_host: str = "",
     inventory_vars: HostVarsType | None = None,
 ) -> str:
-    """Returns the generic UI group label for a workspace."""
+    """Returns the generic UI group label for a workspace.
+
+    Explicit ui_group wins. Inventory-derived grouping is resolved from the
+    current host, so it can be blank during bootstrap and appear once the worker
+    starts processing a host.
+    """
     if workspace.cfg.ui_group:
         return workspace.cfg.ui_group
     if not current_host or not inventory_vars:
@@ -820,6 +826,7 @@ def workspace_event_for_ansible_task_start(
     hostname: str,
     event_data: Mapping[str, Any],
 ) -> WorkspaceEvent | None:
+    """Extracts an executing role/task from ansible_runner events for the workspace log."""
     if event_data.get("event") != "playbook_on_task_start":
         return None
 
@@ -840,6 +847,7 @@ def workspace_event_for_ansible_task_start(
 
 
 def queue_ansible_task_start_event(hostname: str, event_data: Mapping[str, Any]) -> bool:
+    """ansible_runner event handler that logs task starts to the active workspace."""
     if boardwalkd_client and (event := workspace_event_for_ansible_task_start(hostname, event_data)):
         boardwalkd_client.queue_event(event)
     return True

--- a/src/boardwalk/cli_run.py
+++ b/src/boardwalk/cli_run.py
@@ -11,9 +11,10 @@ import random
 import socket
 import sys
 import time
+from collections.abc import Mapping
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import ansible_runner
 import click
@@ -209,6 +210,7 @@ def run(
         inventory_vars=inventory_vars,
         workspace=ws,
         verbosity=ctx.obj["VERBOSITY"],
+        ctx=ctx,
     )
 
 
@@ -266,11 +268,22 @@ def run_workflow(
     inventory_vars: HostVarsType,
     workspace: Workspace,
     verbosity: int,
+    ctx: click.Context,
 ):
     """Runs the workspace's workflow against a list of hosts"""
     i = 0
     while i < len(hosts):
         host = hosts[i]
+
+        if boardwalkd_client:
+            boardwalkd_client.post_details(
+                build_workspace_details(
+                    workspace=workspace,
+                    ctx=ctx,
+                    current_host=host.name,
+                    inventory_vars=inventory_vars,
+                )
+            )
 
         logger.info(f"{host.name}: Workflow iteration on host {i + 1} of {len(hosts)}")
         if boardwalkd_client:
@@ -622,6 +635,53 @@ def lock_remote_host(host: Host):
     )
 
 
+def resolve_workspace_ui_group(
+    workspace: Workspace,
+    current_host: str = "",
+    inventory_vars: HostVarsType | None = None,
+) -> str:
+    """Returns the generic UI group label for a workspace."""
+    if workspace.cfg.ui_group:
+        return workspace.cfg.ui_group
+    if not current_host or not inventory_vars:
+        return ""
+    if not workspace.cfg.ui_group_inventory_var:
+        return ""
+    host_vars = inventory_vars.get(current_host, {})
+    return str(host_vars.get(workspace.cfg.ui_group_inventory_var, "") or "")
+
+
+def build_workspace_details(
+    workspace: Workspace,
+    ctx: click.Context,
+    current_host: str = "",
+    inventory_vars: HostVarsType | None = None,
+) -> WorkspaceDetails:
+    """Builds worker details posted to boardwalkd."""
+    worker_limit = ctx.params.get("limit")
+    return WorkspaceDetails(
+        current_host=current_host,
+        deployment_url=os.environ.get("BUILD_URL") or os.environ.get("RUN_DISPLAY_URL") or "",
+        deployment_name=os.environ.get("JOB_NAME") or "",
+        deployment_number=os.environ.get("BUILD_NUMBER") or "",
+        deployment_tag=os.environ.get("BUILD_TAG") or "",
+        deployment_user=os.environ.get("BUILD_USER") or "",
+        deployment_user_id=os.environ.get("BUILD_USER_ID") or "",
+        deployment_user_email=os.environ.get("BUILD_USER_EMAIL") or "",
+        host_pattern=workspace.cfg.host_pattern,
+        ui_group=resolve_workspace_ui_group(
+            workspace=workspace,
+            current_host=current_host,
+            inventory_vars=inventory_vars,
+        ),
+        workflow=workspace.cfg.workflow.__class__.__qualname__,
+        worker_command="check" if _check_mode else "run",
+        worker_hostname=socket.gethostname(),
+        worker_limit=str(worker_limit) if worker_limit else "",
+        worker_username=getpass.getuser(),
+    )
+
+
 def bootstrap_with_server(workspace: Workspace, ctx: click.Context):
     """Performs all of the initial set-up actions needed when boardwalk is
     configured to connect to a central boardwalkd"""
@@ -659,23 +719,7 @@ def bootstrap_with_server(workspace: Workspace, ctx: click.Context):
 
     # Post the worker's details, which also creates the workspace
     try:
-        boardwalkd_client.post_details(
-            WorkspaceDetails(
-                deployment_url=auth_login_context.get("deployment_url") or "",
-                deployment_name=auth_login_context.get("deployment_name") or "",
-                deployment_number=auth_login_context.get("deployment_number") or "",
-                deployment_tag=auth_login_context.get("deployment_tag") or "",
-                deployment_user=auth_login_context.get("deployment_user") or "",
-                deployment_user_id=auth_login_context.get("deployment_user_id") or "",
-                deployment_user_email=auth_login_context.get("deployment_user_email") or "",
-                host_pattern=workspace.cfg.host_pattern,
-                workflow=workspace.cfg.workflow.__class__.__qualname__,
-                worker_command="check" if _check_mode else "run",
-                worker_hostname=socket.gethostname(),
-                worker_limit=ctx.params.get("limit"),  # type: ignore
-                worker_username=getpass.getuser(),
-            )
-        )
+        boardwalkd_client.post_details(build_workspace_details(workspace=workspace, ctx=ctx))
     except ConnectionRefusedError:
         raise BoardwalkException(f"Could not connect to server {boardwalkd_url}")
 
@@ -769,6 +813,35 @@ def directly_confirm_host_preconditions(host: Host, inventory_vars: InventoryHos
     return True
 
 
+def workspace_event_for_ansible_task_start(
+    hostname: str,
+    event_data: Mapping[str, Any],
+) -> WorkspaceEvent | None:
+    if event_data.get("event") != "playbook_on_task_start":
+        return None
+
+    raw_event_details = event_data.get("event_data", {})
+    if not isinstance(raw_event_details, Mapping):
+        return None
+
+    task = str(raw_event_details.get("task") or "").strip()
+    if not task:
+        return None
+
+    role = str(raw_event_details.get("role") or "").strip()
+    task_label = f"{role} : {task}" if role else task
+    return WorkspaceEvent(
+        severity="info",
+        message=f"{hostname}: Running Ansible task {task_label}",
+    )
+
+
+def queue_ansible_task_start_event(hostname: str, event_data: Mapping[str, Any]) -> bool:
+    if boardwalkd_client and (event := workspace_event_for_ansible_task_start(hostname, event_data)):
+        boardwalkd_client.queue_event(event)
+    return True
+
+
 def execute_workflow_jobs(host: Host, workspace: Workspace, job_kind: str, verbosity: int):
     """
     Executes workflow jobs. Different kinds of job types are specified
@@ -813,6 +886,7 @@ def execute_workflow_jobs(host: Host, workspace: Workspace, job_kind: str, verbo
                 quiet=False,
                 tasks=tasks,
                 extra_vars=job.options,
+                event_handler=lambda event_data: queue_ansible_task_start_event(host.name, event_data),
             )
 
 

--- a/src/boardwalk/host.py
+++ b/src/boardwalk/host.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import getpass
 import socket
 from base64 import b64decode
+from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -50,6 +51,7 @@ class Host(BaseModel, extra="forbid"):
         gather_facts: bool = True,
         quiet: bool = True,
         extra_vars: dict = {},
+        event_handler: Callable[[dict[str, Any]], bool] | None = None,
     ) -> Runner:
         """
         Wraps ansible_runner_run_tasks for performing Ansible tasks against this host
@@ -66,6 +68,7 @@ class Host(BaseModel, extra="forbid"):
             gather_facts=gather_facts,
             quiet=quiet,
             extra_vars=extra_vars,
+            event_handler=event_handler,
         )
 
     def is_locked(self) -> str | bool:

--- a/src/boardwalk/manifest.py
+++ b/src/boardwalk/manifest.py
@@ -93,11 +93,15 @@ def get_ws() -> Workspace:
 
 
 def get_boardwalkd_url() -> str:
+    if boardwalkd_url_override := os.environ.get("BOARDWALKD_URL"):
+        return boardwalkd_url_override
+
     try:
         sys.path.append(str(Path.cwd()))
-        from Boardwalkfile import boardwalkd_url  # type: ignore
-
-        sys.path.pop()
+        try:
+            from Boardwalkfile import boardwalkd_url  # type: ignore
+        finally:
+            sys.path.pop()
     except ModuleNotFoundError:
         raise ManifestNotFound
     except ImportError:
@@ -276,6 +280,9 @@ class WorkspaceConfig:
     option to be passed. This is useful for workspaces configured with a broad
     host pattern but workflows should be intentionally down-scoped to a specific
     pattern
+    :param ui_group: Optional static UI grouping label used by boardwalkd.
+    :param ui_group_inventory_var: Optional inventory hostvar name used to derive
+    the UI grouping label from the current host during a run.
     :param workflow: The workflow the workspace uses
     """
 
@@ -287,10 +294,14 @@ class WorkspaceConfig:
         workflow: Workflow,
         default_sort_order: str = "shuffle",
         require_limit: bool = False,
+        ui_group: str = "",
+        ui_group_inventory_var: str = "",
     ):
         self.default_sort_order = default_sort_order
         self.host_pattern = host_pattern
         self.require_limit = require_limit
+        self.ui_group = ui_group
+        self.ui_group_inventory_var = ui_group_inventory_var
         self.workflow = workflow
 
     @property

--- a/src/boardwalk/manifest.py
+++ b/src/boardwalk/manifest.py
@@ -93,9 +93,7 @@ def get_ws() -> Workspace:
 
 
 def get_boardwalkd_url() -> str:
-    if boardwalkd_url_override := os.environ.get("BOARDWALKD_URL"):
-        return boardwalkd_url_override
-
+    """Returns the boardwalkd URL from the active Boardwalkfile."""
     try:
         sys.path.append(str(Path.cwd()))
         try:

--- a/src/boardwalkd/broadcast.py
+++ b/src/boardwalkd/broadcast.py
@@ -66,6 +66,7 @@ async def handle_auth_login_broadcast(
     webhook_url: str | None,
     error_webhook_url: str | None,
     server_url: str,
+    slack_user_mention: str | None = None,
 ):
     """Posts a Slack notification when a worker is waiting for API authentication."""
     webhook_url = error_webhook_url or webhook_url
@@ -80,6 +81,9 @@ async def handle_auth_login_broadcast(
             )
         ),
     ]
+    if slack_user_mention:
+        slack_message_blocks.append(SectionBlock(text=MarkdownTextObject(text=f"*Notifying:* {slack_user_mention}")))
+
     context_fields = _auth_login_context_fields(auth_context=auth_context, server_url=server_url)
     for i in range(0, len(context_fields), 10):
         slack_message_blocks.append(SectionBlock(fields=context_fields[i : i + 10]))

--- a/src/boardwalkd/cli.py
+++ b/src/boardwalkd/cli.py
@@ -86,7 +86,7 @@ def cli():
 @click.option(
     "--demo/--no-demo",
     default=False,
-    help="Seed generic demo workspace rows when the state file is empty",
+    help="Loads generic demo workspace rows into the `boardwalkd` state, only if the state is empty",
     show_default=True,
 )
 @click.option(
@@ -198,15 +198,46 @@ def cli():
 )
 @click.option(
     "--theme-static-path",
+    help="Directory of private theme assets to serve under /theme-static/",
     type=click.Path(exists=True, file_okay=False, readable=True),
     default=None,
     show_envvar=True,
 )
-@click.option("--theme-css-url", type=str, default="", show_envvar=True)
-@click.option("--theme-logo-url", type=str, default="", show_envvar=True)
-@click.option("--theme-logo-alt", type=str, default="", show_envvar=True)
-@click.option("--theme-brand-name", type=str, default="Boardwalk", show_envvar=True)
-@click.option("--jenkins-job-url", type=str, default="", show_envvar=True)
+@click.option(
+    "--theme-css-url",
+    help="Optional CSS URL loaded after the bundled boardwalkd stylesheet",
+    type=str,
+    default="",
+    show_envvar=True,
+)
+@click.option(
+    "--theme-logo-url",
+    help="Optional logo image URL for the top-left brand mark",
+    type=str,
+    default="",
+    show_envvar=True,
+)
+@click.option(
+    "--theme-logo-alt",
+    help="Alt text for the themed logo; defaults to the brand name in templates",
+    type=str,
+    default="",
+    show_envvar=True,
+)
+@click.option(
+    "--theme-brand-name",
+    help="Brand name rendered in the dashboard header and page title",
+    type=str,
+    default="Boardwalk",
+    show_envvar=True,
+)
+@click.option(
+    "--jenkins-job-url",
+    help="Base Jenkins job URL used to link workspace build numbers to build pages",
+    type=str,
+    default="",
+    show_envvar=True,
+)
 @click.option(
     "--url",
     help=(

--- a/src/boardwalkd/cli.py
+++ b/src/boardwalkd/cli.py
@@ -3,9 +3,12 @@ This file contains the boardwalkd CLI code
 """
 
 import asyncio
+import json
 import re
 import sys
+from datetime import UTC, datetime
 from importlib.metadata import version as lib_version
+from pathlib import Path
 
 import click
 from email_validator import EmailNotValidError, validate_email
@@ -14,6 +17,8 @@ from loguru import logger
 from boardwalk.app_exceptions import BoardwalkException
 from boardwalkd.server import run
 from boardwalkd.slack_error_advice import SlackErrorAdviceConfigError, parse_slack_error_advice_config
+from boardwalkd.snapshot import load_inventory_context
+from boardwalkd.snapshot import sanitize_status_snapshot as sanitize_status_snapshot_data
 
 CONTEXT_SETTINGS: dict = dict(
     auto_envvar_prefix="BOARDWALKD",
@@ -77,6 +82,12 @@ def cli():
     default=False,
     help="Runs the server in development mode with auto-reloading and tracebacks",
     show_default=True,
+)
+@click.option(
+    "--develop-snapshot",
+    type=click.Path(exists=True, readable=True, dir_okay=False),
+    default=None,
+    help="Seed development workspaces from a redacted /api/workspaces/status snapshot",
 )
 @click.option(
     "--host-header-pattern",
@@ -180,6 +191,17 @@ def cli():
     default=None,
 )
 @click.option(
+    "--theme-static-path",
+    type=click.Path(exists=True, file_okay=False, readable=True),
+    default=None,
+    show_envvar=True,
+)
+@click.option("--theme-css-url", type=str, default="", show_envvar=True)
+@click.option("--theme-logo-url", type=str, default="", show_envvar=True)
+@click.option("--theme-logo-alt", type=str, default="", show_envvar=True)
+@click.option("--theme-brand-name", type=str, default="Boardwalk", show_envvar=True)
+@click.option("--jenkins-job-url", type=str, default="", show_envvar=True)
+@click.option(
     "--url",
     help=(
         "The base URL where the server can be reached. UI Requests that do not"
@@ -210,6 +232,7 @@ def serve(
     auth_expire_days: float,
     auth_method: str,
     develop: bool,
+    develop_snapshot: str | None,
     host_header_pattern: str,
     owner: str | None,
     port: int | None,
@@ -219,6 +242,12 @@ def serve(
     slack_bot_token: str | None,
     slack_error_advice_config: str | None,
     slack_slash_command_prefix: str,
+    theme_static_path: str | None,
+    theme_css_url: str,
+    theme_logo_url: str,
+    theme_logo_alt: str,
+    theme_brand_name: str,
+    jenkins_job_url: str,
     tls_crt: str | None,
     tls_key: str | None,
     tls_port: int | None,
@@ -234,6 +263,9 @@ def serve(
     logger.info(f"Log level is {loglevel}")
 
     logger.warning("boardwalkd is running in development mode, which should not be used in a production environment")
+
+    if develop_snapshot and not develop:
+        raise BoardwalkException("--develop-snapshot requires --develop")
 
     # Validate host_header_pattern
     try:
@@ -286,6 +318,7 @@ def serve(
             auth_login_slack_notify=auth_login_slack_notify,
             auth_method=auth_method,
             develop=develop,
+            develop_snapshot_path=develop_snapshot,
             host_header_pattern=host_header_regex,
             owner=owner,
             port_number=port,
@@ -295,6 +328,12 @@ def serve(
             slack_error_webhook_url=slack_error_webhook_url,
             slack_webhook_url=slack_webhook_url,
             slack_slash_command_prefix=slack_slash_command_prefix,
+            theme_static_path=theme_static_path,
+            theme_css_url=theme_css_url,
+            theme_logo_url=theme_logo_url,
+            theme_logo_alt=theme_logo_alt,
+            theme_brand_name=theme_brand_name,
+            jenkins_job_url=jenkins_job_url,
             tls_crt_path=tls_crt,
             tls_key_path=tls_key,
             tls_port_number=tls_port,
@@ -302,6 +341,47 @@ def serve(
             workspace_status_json=workspace_status_json,
         )
     )
+
+
+@cli.command("sanitize-status-snapshot")
+@click.argument("source", type=click.Path(exists=True, readable=True, dir_okay=False))
+@click.argument("destination", type=click.Path(dir_okay=False))
+@click.option(
+    "--captured-at",
+    type=str,
+    default=None,
+    help="ISO-8601 timestamp to use as the snapshot capture time. Defaults to now.",
+)
+@click.option(
+    "--preserve-identifiers/--redact-identifiers",
+    default=False,
+    help="Keep workspace/user/host identifiers for private local replay.",
+    show_default=True,
+)
+@click.option(
+    "--inventory-json",
+    type=click.Path(exists=True, readable=True, dir_okay=False),
+    default=None,
+    help="Optional ansible-inventory --list --export JSON used to derive ui_group from group ancestry.",
+)
+def sanitize_status_snapshot(
+    source: str,
+    destination: str,
+    captured_at: str | None,
+    preserve_identifiers: bool,
+    inventory_json: str | None,
+):
+    """Converts a /api/workspaces/status JSON snapshot for local development replay."""
+    now = datetime.fromisoformat(captured_at).replace(tzinfo=UTC) if captured_at else None
+    raw_snapshot = json.loads(Path(source).read_text())
+    sanitized = sanitize_status_snapshot_data(
+        raw_snapshot,
+        now=now,
+        preserve_identifiers=preserve_identifiers,
+        inventory=load_inventory_context(inventory_json),
+    )
+    Path(destination).write_text(json.dumps(sanitized, indent=2, sort_keys=True) + "\n")
+    click.echo(f"Wrote sanitized snapshot to {destination}")
 
 
 @cli.command(

--- a/src/boardwalkd/cli.py
+++ b/src/boardwalkd/cli.py
@@ -84,6 +84,12 @@ def cli():
     show_default=True,
 )
 @click.option(
+    "--demo/--no-demo",
+    default=False,
+    help="Seed generic demo workspace rows when the state file is empty",
+    show_default=True,
+)
+@click.option(
     "--develop-snapshot",
     type=click.Path(exists=True, readable=True, dir_okay=False),
     default=None,
@@ -232,6 +238,7 @@ def serve(
     auth_expire_days: float,
     auth_method: str,
     develop: bool,
+    demo: bool,
     develop_snapshot: str | None,
     host_header_pattern: str,
     owner: str | None,
@@ -266,6 +273,8 @@ def serve(
 
     if develop_snapshot and not develop:
         raise BoardwalkException("--develop-snapshot requires --develop")
+    if develop_snapshot and demo:
+        raise BoardwalkException("--demo cannot be combined with --develop-snapshot")
 
     # Validate host_header_pattern
     try:
@@ -321,6 +330,7 @@ def serve(
             auth_login_slack_notify=auth_login_slack_notify,
             auth_method=auth_method,
             develop=develop,
+            demo=demo,
             develop_snapshot_path=develop_snapshot,
             host_header_pattern=host_header_regex,
             owner=owner,

--- a/src/boardwalkd/dashboard.py
+++ b/src/boardwalkd/dashboard.py
@@ -284,21 +284,19 @@ def _normalized_filters(filters: DashboardFilters) -> DashboardFilters:
 
 
 ACTIVE_STATUS_PRIORITY = {
-    "caught": 0,
-    "running": 1,
+    "running": 0,
 }
 
-ATTENTION_STATUS_PRIORITY = {
-    "error": 1,
-    "caught": 2,
+CAUGHT_STATUS_PRIORITY = {
+    "caught": 0,
+}
+
+INACTIVE_STATUS_PRIORITY = {
+    "error": 0,
+    "caught": 1,
     "stale": 3,
     "idle": 4,
-}
-
-QUIET_STATUS_PRIORITY = {
-    "done": 0,
-    "idle": 1,
-    "stale": 2,
+    "done": 5,
 }
 
 COLUMN_STATUS_PRIORITY = {
@@ -312,29 +310,29 @@ COLUMN_STATUS_PRIORITY = {
 
 
 def _lane_key(row: DashboardRow) -> str:
+    if row.worker_connected and row.caught:
+        return "caught"
     if row.worker_connected:
         return "active"
-    if row.advice or row.status in {"error", "caught"} or row.has_mutex:
-        return "attention"
-    return "quiet"
+    return "inactive"
 
 
 def _default_lane_sort_key(lane_key: str):
     def active_key(row: DashboardRow) -> tuple[int, tuple[int, int, int], str]:
         return (ACTIVE_STATUS_PRIORITY.get(row.status, 99), _time_desc_key(row.latest_event_time), row.name.casefold())
 
-    def attention_key(row: DashboardRow) -> tuple[int, tuple[int, int, int], str]:
-        status_priority = 0 if row.advice else ATTENTION_STATUS_PRIORITY.get(row.status, 99)
-        return (status_priority, _time_asc_key(row.latest_event_time), row.name.casefold())
+    def caught_key(row: DashboardRow) -> tuple[int, tuple[int, int, int], str]:
+        return (CAUGHT_STATUS_PRIORITY.get(row.status, 99), _time_asc_key(row.latest_event_time), row.name.casefold())
 
-    def quiet_key(row: DashboardRow) -> tuple[int, tuple[int, int, int], str]:
-        return (QUIET_STATUS_PRIORITY.get(row.status, 99), _time_desc_key(row.latest_event_time), row.name.casefold())
+    def inactive_key(row: DashboardRow) -> tuple[int, tuple[int, int, int], str]:
+        status_priority = 0 if row.advice else 2 if row.has_mutex else INACTIVE_STATUS_PRIORITY.get(row.status, 99)
+        return (status_priority, _time_asc_key(row.latest_event_time), row.name.casefold())
 
     if lane_key == "active":
         return active_key
-    if lane_key == "attention":
-        return attention_key
-    return quiet_key
+    if lane_key == "caught":
+        return caught_key
+    return inactive_key
 
 
 def _column_sort_key(sort: str):
@@ -363,14 +361,14 @@ def _sort_lane_rows(rows: list[DashboardRow], filters: DashboardFilters, lane_ke
 
 
 def _build_lanes(rows: Sequence[DashboardRow], filters: DashboardFilters) -> list[DashboardLane]:
-    grouped_rows = {"active": [], "attention": [], "quiet": []}
+    grouped_rows = {"active": [], "caught": [], "inactive": []}
     for row in rows:
         grouped_rows[_lane_key(row)].append(row)
 
     lanes = [
-        ("active", "Active work"),
-        ("attention", "Needs attention"),
-        ("quiet", "Quiet work"),
+        ("active", "Active workspaces"),
+        ("caught", "Caught workspaces"),
+        ("inactive", "Inactive workspaces"),
     ]
     return [
         DashboardLane(key=key, label=label, rows=_sort_lane_rows(grouped_rows[key], filters, key))

--- a/src/boardwalkd/dashboard.py
+++ b/src/boardwalkd/dashboard.py
@@ -1,0 +1,487 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlencode
+
+from boardwalkd.protocol import WorkspaceEvent
+from boardwalkd.slack_error_advice import SlackErrorAdviceRule, matching_error_advice
+from boardwalkd.state import WorkspaceState
+
+ALL_GROUP = "All"
+UNGROUPED = "Ungrouped"
+STALE_AFTER = timedelta(hours=24)
+DEFAULT_SORT = "default"
+DEFAULT_DIRECTION = "asc"
+SORT_COLUMNS = {"workspace", "current_host", "source", "status", "updated"}
+SORT_DIRECTIONS = {"asc", "desc"}
+
+
+@dataclass(frozen=True)
+class DashboardFilters:
+    group: str = ALL_GROUP
+    search: str = ""
+    status: str = "all"
+    source: str = "all"
+    sort: str = DEFAULT_SORT
+    direction: str = DEFAULT_DIRECTION
+
+
+@dataclass(frozen=True)
+class DashboardGroup:
+    label: str
+    count: int
+    active: bool
+
+
+@dataclass(frozen=True)
+class DashboardAdvice:
+    name: str
+    message: str
+
+
+@dataclass(frozen=True)
+class DashboardRow:
+    name: str
+    group: str
+    workflow: str
+    user: str
+    worker: str
+    worker_connected: bool
+    host_pattern: str
+    limit_pattern: str
+    current_host: str
+    command: str
+    source: str
+    source_label: str
+    source_url: str
+    status: str
+    latest_event: str
+    latest_event_time: datetime
+    events: list[WorkspaceEvent]
+    advice: list[DashboardAdvice]
+    caught: bool
+    has_mutex: bool
+    stale: bool
+    can_request_remote_cleanup: bool
+
+
+@dataclass(frozen=True)
+class DashboardLane:
+    key: str
+    label: str
+    rows: list[DashboardRow]
+
+    @property
+    def count(self) -> int:
+        return len(self.rows)
+
+
+@dataclass(frozen=True)
+class Dashboard:
+    filters: DashboardFilters
+    groups: list[DashboardGroup]
+    lanes: list[DashboardLane]
+    rows: list[DashboardRow]
+    total_count: int
+    running_count: int
+    caught_count: int
+    error_count: int
+    done_count: int
+    stale_count: int
+
+
+def group_for_workspace(workspace: WorkspaceState) -> str:
+    return workspace.details.ui_group or UNGROUPED
+
+
+def _event_time(event: WorkspaceEvent) -> datetime:
+    if event.create_time is None:
+        return datetime.min.replace(tzinfo=UTC)
+    return event.create_time.replace(tzinfo=UTC)
+
+
+def _time_asc_key(value: datetime) -> tuple[int, int, int]:
+    return (value.toordinal(), value.hour * 3600 + value.minute * 60 + value.second, value.microsecond)
+
+
+def _time_desc_key(value: datetime) -> tuple[int, int, int]:
+    ordinal, seconds, microseconds = _time_asc_key(value)
+    return (-ordinal, -seconds, -microseconds)
+
+
+def latest_event(workspace: WorkspaceState) -> str:
+    if not workspace.events:
+        return ""
+    event = max(workspace.events, key=_event_time)
+    return event.message
+
+
+def latest_event_time(workspace: WorkspaceState) -> datetime:
+    if workspace.events:
+        return max(_event_time(event) for event in workspace.events)
+    if workspace.last_seen is not None:
+        return _normalized_time(workspace.last_seen)
+    return datetime.min.replace(tzinfo=UTC)
+
+
+def _normalized_time(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC)
+
+
+def worker_connected(workspace: WorkspaceState, now: datetime | None = None) -> bool:
+    if workspace.last_seen is None:
+        return False
+    now = _normalized_time(now or datetime.now(UTC))
+    return (now - _normalized_time(workspace.last_seen)).total_seconds() < 10
+
+
+def worker_stale(workspace: WorkspaceState, now: datetime | None = None) -> bool:
+    if workspace.last_seen is None:
+        return False
+    now = _normalized_time(now or datetime.now(UTC))
+    return now - _normalized_time(workspace.last_seen) > STALE_AFTER
+
+
+def _latest_terminal_event(workspace: WorkspaceState) -> WorkspaceEvent | None:
+    terminal_events = [event for event in workspace.events if event.severity in {"error", "success"}]
+    if not terminal_events:
+        return None
+    return max(terminal_events, key=_event_time)
+
+
+def status_for_workspace(workspace: WorkspaceState, now: datetime | None = None) -> str:
+    if workspace.semaphores.caught:
+        return "caught"
+    if worker_connected(workspace, now=now):
+        return "running"
+    terminal_event = _latest_terminal_event(workspace)
+    if terminal_event is not None:
+        if terminal_event.severity == "error":
+            return "error"
+        if terminal_event.severity == "success":
+            return "done"
+    if worker_stale(workspace, now=now):
+        return "stale"
+    return "idle"
+
+
+def source_for_workspace(workspace: WorkspaceState, jenkins_job_url: str = "") -> tuple[str, str, str]:
+    build = workspace.details.deployment_number
+    deployment_url = workspace.details.deployment_url
+    if build and jenkins_job_url:
+        return ("jenkins", f"build {build}", f"{jenkins_job_url.rstrip('/')}/{build}/")
+    if deployment_url:
+        return ("deployment", f"build {build}" if build else "deployment", deployment_url)
+    return ("local", "local", "")
+
+
+def row_for_workspace(
+    name: str,
+    workspace: WorkspaceState,
+    jenkins_job_url: str = "",
+    error_advice_rules: Sequence[SlackErrorAdviceRule] = (),
+    now: datetime | None = None,
+) -> DashboardRow:
+    source, source_label, source_url = source_for_workspace(workspace, jenkins_job_url=jenkins_job_url)
+    connected = worker_connected(workspace, now=now)
+    stale = worker_stale(workspace, now=now)
+    status = status_for_workspace(workspace, now=now)
+    terminal_event = _latest_terminal_event(workspace)
+    advice = [
+        DashboardAdvice(name=rule.name, message=rule.message)
+        for rule in (matching_error_advice(terminal_event, list(error_advice_rules)) if status == "error" and terminal_event else [])
+    ]
+    return DashboardRow(
+        name=name,
+        group=group_for_workspace(workspace),
+        workflow=workspace.details.workflow,
+        user=workspace.details.deployment_user or workspace.details.worker_username,
+        worker=f"{workspace.details.worker_username}@{workspace.details.worker_hostname}",
+        worker_connected=connected,
+        host_pattern=workspace.details.host_pattern,
+        limit_pattern=workspace.details.worker_limit or "all",
+        current_host=workspace.details.current_host,
+        command=workspace.details.worker_command,
+        source=source,
+        source_label=source_label,
+        source_url=source_url,
+        status=status,
+        latest_event=latest_event(workspace),
+        latest_event_time=latest_event_time(workspace),
+        events=sorted(workspace.events, key=_event_time, reverse=True),
+        advice=advice,
+        caught=workspace.semaphores.caught,
+        has_mutex=workspace.semaphores.has_mutex,
+        stale=stale,
+        can_request_remote_cleanup=workspace.semaphores.caught and connected,
+    )
+
+
+def _group_sort_key(group: str) -> tuple[int, str]:
+    if group == UNGROUPED:
+        return (1, group.casefold())
+    return (0, group.casefold())
+
+
+def group_counts(rows: Sequence[DashboardRow]) -> dict[str, int]:
+    counts = {ALL_GROUP: len(rows)}
+    for row in rows:
+        counts[row.group] = counts.get(row.group, 0) + 1
+    return counts
+
+
+def _matches_filters(row: DashboardRow, filters: DashboardFilters, *, include_group: bool = True) -> bool:
+    if include_group and filters.group and filters.group != ALL_GROUP and row.group != filters.group:
+        return False
+    if filters.status and filters.status != "all" and row.status != filters.status:
+        return False
+    if filters.source and filters.source != "all" and row.source != filters.source:
+        return False
+    if filters.search:
+        query = filters.search.casefold()
+        searchable = " ".join(
+            [
+                row.name,
+                row.current_host,
+                row.limit_pattern,
+                row.user,
+                row.worker,
+                row.source,
+                row.source_label,
+                row.source_url,
+                " ".join(advice.name for advice in row.advice),
+                " ".join(advice.message for advice in row.advice),
+            ]
+        ).casefold()
+        if query not in searchable:
+            return False
+    return True
+
+
+def _normalized_sort(sort: str) -> str:
+    return sort if sort in SORT_COLUMNS else DEFAULT_SORT
+
+
+def _normalized_direction(direction: str) -> str:
+    return direction if direction in SORT_DIRECTIONS else DEFAULT_DIRECTION
+
+
+def _normalized_filters(filters: DashboardFilters) -> DashboardFilters:
+    return DashboardFilters(
+        group=filters.group,
+        search=filters.search,
+        status=filters.status,
+        source=filters.source,
+        sort=_normalized_sort(filters.sort),
+        direction=_normalized_direction(filters.direction),
+    )
+
+
+ACTIVE_STATUS_PRIORITY = {
+    "caught": 0,
+    "running": 1,
+}
+
+ATTENTION_STATUS_PRIORITY = {
+    "error": 1,
+    "caught": 2,
+    "stale": 3,
+    "idle": 4,
+}
+
+QUIET_STATUS_PRIORITY = {
+    "done": 0,
+    "idle": 1,
+    "stale": 2,
+}
+
+COLUMN_STATUS_PRIORITY = {
+    "caught": 0,
+    "running": 1,
+    "error": 2,
+    "done": 3,
+    "idle": 4,
+    "stale": 5,
+}
+
+
+def _lane_key(row: DashboardRow) -> str:
+    if row.worker_connected:
+        return "active"
+    if row.advice or row.status in {"error", "caught"} or row.has_mutex:
+        return "attention"
+    return "quiet"
+
+
+def _default_lane_sort_key(lane_key: str):
+    def active_key(row: DashboardRow) -> tuple[int, tuple[int, int, int], str]:
+        return (ACTIVE_STATUS_PRIORITY.get(row.status, 99), _time_desc_key(row.latest_event_time), row.name.casefold())
+
+    def attention_key(row: DashboardRow) -> tuple[int, tuple[int, int, int], str]:
+        status_priority = 0 if row.advice else ATTENTION_STATUS_PRIORITY.get(row.status, 99)
+        return (status_priority, _time_asc_key(row.latest_event_time), row.name.casefold())
+
+    def quiet_key(row: DashboardRow) -> tuple[int, tuple[int, int, int], str]:
+        return (QUIET_STATUS_PRIORITY.get(row.status, 99), _time_desc_key(row.latest_event_time), row.name.casefold())
+
+    if lane_key == "active":
+        return active_key
+    if lane_key == "attention":
+        return attention_key
+    return quiet_key
+
+
+def _column_sort_key(sort: str):
+    if sort == "workspace":
+        return lambda row: row.name.casefold()
+    if sort == "current_host":
+        return lambda row: (row.current_host or "unknown").casefold()
+    if sort == "source":
+        return lambda row: (row.source, row.source_label.casefold(), row.name.casefold())
+    if sort == "status":
+        return lambda row: COLUMN_STATUS_PRIORITY.get(row.status, 99)
+    if sort == "updated":
+        return lambda row: _time_asc_key(row.latest_event_time)
+    return lambda row: row.name.casefold()
+
+
+def _sort_lane_rows(rows: list[DashboardRow], filters: DashboardFilters, lane_key: str) -> list[DashboardRow]:
+    sorted_rows = list(rows)
+    if filters.sort == DEFAULT_SORT:
+        sorted_rows.sort(key=_default_lane_sort_key(lane_key))
+        return sorted_rows
+
+    sorted_rows.sort(key=lambda row: row.name.casefold())
+    sorted_rows.sort(key=_column_sort_key(filters.sort), reverse=filters.direction == "desc")
+    return sorted_rows
+
+
+def _build_lanes(rows: Sequence[DashboardRow], filters: DashboardFilters) -> list[DashboardLane]:
+    grouped_rows = {"active": [], "attention": [], "quiet": []}
+    for row in rows:
+        grouped_rows[_lane_key(row)].append(row)
+
+    lanes = [
+        ("active", "Active work"),
+        ("attention", "Needs attention"),
+        ("quiet", "Quiet work"),
+    ]
+    return [
+        DashboardLane(key=key, label=label, rows=_sort_lane_rows(grouped_rows[key], filters, key))
+        for key, label in lanes
+        if grouped_rows[key]
+    ]
+
+
+def build_dashboard(
+    workspaces: Mapping[str, WorkspaceState],
+    filters: DashboardFilters,
+    jenkins_job_url: str = "",
+    error_advice_rules: Sequence[SlackErrorAdviceRule] = (),
+    now: datetime | None = None,
+) -> Dashboard:
+    filters = _normalized_filters(filters)
+    all_rows = [
+        row_for_workspace(
+            name,
+            workspace,
+            jenkins_job_url=jenkins_job_url,
+            error_advice_rules=error_advice_rules,
+            now=now,
+        )
+        for name, workspace in workspaces.items()
+    ]
+    count_rows = [row for row in all_rows if _matches_filters(row, filters, include_group=False)]
+    counts = group_counts(count_rows)
+    group_labels = sorted({row.group for row in all_rows}, key=_group_sort_key)
+    groups = [
+        DashboardGroup(label=ALL_GROUP, count=counts[ALL_GROUP], active=filters.group in {"", ALL_GROUP}),
+        *[
+            DashboardGroup(label=label, count=counts.get(label, 0), active=filters.group == label)
+            for label in group_labels
+        ],
+    ]
+    visible_rows = [row for row in all_rows if _matches_filters(row, filters)]
+    lanes = _build_lanes(visible_rows, filters)
+    rows = [row for lane in lanes for row in lane.rows]
+    return Dashboard(
+        filters=filters,
+        groups=groups,
+        lanes=lanes,
+        rows=rows,
+        total_count=len(rows),
+        running_count=sum(1 for row in rows if row.status == "running"),
+        caught_count=sum(1 for row in rows if row.status == "caught"),
+        error_count=sum(1 for row in rows if row.status == "error"),
+        done_count=sum(1 for row in rows if row.status == "done"),
+        stale_count=sum(1 for row in rows if row.status == "stale"),
+    )
+
+
+def query_url(path: str, filters: DashboardFilters, **overrides: str) -> str:
+    filters = _normalized_filters(filters)
+    values = {
+        "group": filters.group,
+        "search": filters.search,
+        "status": filters.status,
+        "source": filters.source,
+        "sort": filters.sort,
+        "direction": filters.direction,
+    }
+    values.update(overrides)
+    sort = _normalized_sort(values.get("sort", DEFAULT_SORT))
+    direction = _normalized_direction(values.get("direction", DEFAULT_DIRECTION))
+    values["sort"] = sort
+    values["direction"] = direction
+    query = {
+        key: value
+        for key, value in values.items()
+        if value
+        and value != ALL_GROUP
+        and value != "all"
+        and not (key == "sort" and value == DEFAULT_SORT)
+        and not (key == "direction" and (sort == DEFAULT_SORT or direction == DEFAULT_DIRECTION))
+    }
+    return f"{path}?{urlencode(query)}" if query else path
+
+
+def next_sort_direction(filters: DashboardFilters, column: str) -> str:
+    filters = _normalized_filters(filters)
+    if filters.sort == column and filters.direction == DEFAULT_DIRECTION:
+        return "desc"
+    return DEFAULT_DIRECTION
+
+
+def sort_url(path: str, filters: DashboardFilters, column: str, edit: bool = False, **overrides: str) -> str:
+    if edit:
+        overrides.setdefault("edit", "1")
+    overrides["sort"] = column
+    overrides["direction"] = next_sort_direction(filters, column)
+    return query_url(path, filters, **overrides)
+
+
+def canonical_url(filters: DashboardFilters, edit: bool = False, **overrides: str) -> str:
+    if edit:
+        overrides.setdefault("edit", "1")
+    return query_url("/", filters, **overrides)
+
+
+def action_url(path: str, filters: DashboardFilters, edit: bool = False, **overrides: str) -> str:
+    if edit:
+        overrides.setdefault("edit", "1")
+    return query_url(path, filters, **overrides)
+
+
+def partial_url(
+    filters: DashboardFilters,
+    edit: bool = False,
+    push_url: bool = False,
+    **overrides: str,
+) -> str:
+    if edit:
+        overrides.setdefault("edit", "1")
+    if push_url:
+        overrides.setdefault("push_url", "1")
+    return query_url("/workspaces", filters, **overrides)

--- a/src/boardwalkd/dashboard.py
+++ b/src/boardwalkd/dashboard.py
@@ -191,7 +191,11 @@ def row_for_workspace(
     terminal_event = _latest_terminal_event(workspace)
     advice = [
         DashboardAdvice(name=rule.name, message=rule.message)
-        for rule in (matching_error_advice(terminal_event, list(error_advice_rules)) if status == "error" and terminal_event else [])
+        for rule in (
+            matching_error_advice(terminal_event, list(error_advice_rules))
+            if status == "error" and terminal_event
+            else []
+        )
     ]
     return DashboardRow(
         name=name,

--- a/src/boardwalkd/dashboard.py
+++ b/src/boardwalkd/dashboard.py
@@ -151,6 +151,9 @@ def _latest_terminal_event(workspace: WorkspaceState) -> WorkspaceEvent | None:
     return max(terminal_events, key=_event_time)
 
 
+# Status drives the badge/filter value. Lane placement is handled separately in
+# _lane_key because a caught workspace with no connected worker is operationally
+# different from a caught workspace that can still be released.
 def status_for_workspace(workspace: WorkspaceState, now: datetime | None = None) -> str:
     if workspace.semaphores.caught:
         return "caught"
@@ -309,6 +312,9 @@ COLUMN_STATUS_PRIORITY = {
 }
 
 
+# Lanes describe what the operator can act on now. A caught workspace only stays
+# in the caught lane while a worker heartbeat is active; once disconnected, it is
+# inactive even though its status badge remains caught.
 def _lane_key(row: DashboardRow) -> str:
     if row.worker_connected and row.caught:
         return "caught"
@@ -317,6 +323,9 @@ def _lane_key(row: DashboardRow) -> str:
     return "inactive"
 
 
+# The default ordering is tuned for live operations: active work shows the most
+# recent movement first, caught work shows the longest-waiting pauses first, and
+# inactive work puts likely follow-up items ahead of stale/done history.
 def _default_lane_sort_key(lane_key: str):
     def active_key(row: DashboardRow) -> tuple[int, tuple[int, int, int], str]:
         return (ACTIVE_STATUS_PRIORITY.get(row.status, 99), _time_desc_key(row.latest_event_time), row.name.casefold())

--- a/src/boardwalkd/demo.py
+++ b/src/boardwalkd/demo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import deque
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
@@ -17,7 +18,7 @@ class DemoWorkspace:
     caught: bool = False
     build: str = ""
     severity: str = "info"
-    has_mutex: bool = True
+    has_mutex: bool = False
     stale: bool = False
     extra_events: int = 0
     worker_command: str = "run"
@@ -144,6 +145,7 @@ DEMO_WORKSPACES = [
         host_pattern="nodes_theta",
         current_host="node-theta-b",
         latest_event="Server-side workspace mutex remains after stale worker",
+        has_mutex=True,
         stale=True,
         worker_command="run",
         worker_hostname="demo-worker-retired",
@@ -171,9 +173,7 @@ def seed_development_workspaces(state: State) -> bool:
     for index, example in enumerate(DEMO_WORKSPACES):
         worker_limit = example.worker_limit or example.current_host or "all"
         last_seen = (
-            now - timedelta(days=8, seconds=index)
-            if example.stale
-            else demo_connected_until - timedelta(seconds=index)
+            now - timedelta(days=8, seconds=index) if example.stale else demo_connected_until - timedelta(seconds=index)
         )
         events = [
             WorkspaceEvent(
@@ -183,9 +183,9 @@ def seed_development_workspaces(state: State) -> bool:
             ),
             WorkspaceEvent(
                 severity="info",
-                message=(
-                    f"Derived ui_group={example.ui_group or 'Ungrouped'} "
-                    f"from current_host={example.current_host or 'unknown'}"
+                message="Derived ui_group={} from current_host={}".format(
+                    example.ui_group or "Ungrouped",
+                    example.current_host or "unknown",
                 ),
                 create_time=now - timedelta(seconds=60 + index),
             ),
@@ -216,7 +216,7 @@ def seed_development_workspaces(state: State) -> bool:
                 worker_username="demo",
                 workflow=example.workflow,
             ),
-            events=events,
+            events=deque(events),
             last_seen=last_seen,
             semaphores=WorkspaceSemaphores(caught=example.caught, has_mutex=example.has_mutex),
         )

--- a/src/boardwalkd/demo.py
+++ b/src/boardwalkd/demo.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from boardwalkd.protocol import WorkspaceDetails, WorkspaceEvent, WorkspaceSemaphores
+from boardwalkd.state import State, WorkspaceState
+
+
+@dataclass(frozen=True)
+class DemoWorkspace:
+    name: str
+    ui_group: str
+    host_pattern: str
+    current_host: str
+    latest_event: str
+    caught: bool = False
+    build: str = ""
+    severity: str = "info"
+    has_mutex: bool = True
+    stale: bool = False
+    extra_events: int = 0
+    worker_command: str = "run"
+    worker_hostname: str = "demo-worker-01"
+    worker_limit: str = ""
+    workflow: str = "DemoWorkflow"
+
+
+DEMO_WORKSPACES = [
+    DemoWorkspace(
+        name="nodes_alpha_group_upgrade",
+        ui_group="alpha",
+        host_pattern="nodes_alpha",
+        current_host="node-alpha-a",
+        latest_event="Waiting for remote catch to release",
+        caught=True,
+        build="50321",
+        extra_events=7,
+        workflow="NodeUpgrade",
+    ),
+    DemoWorkspace(
+        name="nodes_beta_group_upgrade",
+        ui_group="beta",
+        host_pattern="nodes_beta",
+        current_host="node-beta-a",
+        latest_event="Running main TASK job DrainNode",
+        build="50322",
+        workflow="NodeUpgrade",
+    ),
+    DemoWorkspace(
+        name="nodes_gamma_group_upgrade",
+        ui_group="gamma",
+        host_pattern="nodes_gamma",
+        current_host="node-gamma-a",
+        latest_event="Locking remote host",
+        build="50323",
+        workflow="NodeUpgrade",
+    ),
+    DemoWorkspace(
+        name="nodes_delta_group_upgrade",
+        ui_group="delta",
+        host_pattern="nodes_delta",
+        current_host="node-delta-a",
+        latest_event="Updating remote state",
+        workflow="NodeUpgrade",
+    ),
+    DemoWorkspace(
+        name="nodes_omega_group_upgrade",
+        ui_group="omega",
+        host_pattern="nodes_omega",
+        current_host="node-omega-a",
+        latest_event="Host completed successfully; wrapping up",
+        severity="success",
+        workflow="NodeUpgrade",
+    ),
+    DemoWorkspace(
+        name="nodes_theta_group_upgrade",
+        ui_group="theta",
+        host_pattern="nodes_theta",
+        current_host="node-theta-a",
+        latest_event="Worker details posted",
+        workflow="NodeUpgrade",
+    ),
+    DemoWorkspace(
+        name="nodes_multi_group_beta_current",
+        ui_group="beta",
+        host_pattern="nodes_alpha:nodes_beta:nodes_gamma",
+        current_host="node-beta-a",
+        latest_event="Derived UI group from current host node-beta-a",
+        build="50324",
+        workflow="MultiGroupCanary",
+    ),
+    DemoWorkspace(
+        name="nodes_multi_group_gamma_current",
+        ui_group="gamma",
+        host_pattern="nodes_alpha:nodes_beta:nodes_gamma",
+        current_host="node-gamma-a",
+        latest_event="Derived UI group from current host node-gamma-a",
+        build="50325",
+        workflow="MultiGroupCanary",
+    ),
+    DemoWorkspace(
+        name="storage_multi_group_alpha_current",
+        ui_group="alpha",
+        host_pattern="storage_alpha:storage_beta:storage_gamma",
+        current_host="storage-alpha-a",
+        latest_event="Storage health check paused for operator catch",
+        build="50326",
+        workflow="StorageMaintenance",
+    ),
+    DemoWorkspace(
+        name="utility_delta_restart",
+        ui_group="delta",
+        host_pattern="utility_delta",
+        current_host="utility-delta-a",
+        latest_event="Restarting boardwalk-safe utility service",
+        workflow="UtilityRestart",
+    ),
+    DemoWorkspace(
+        name="workspace_without_group",
+        ui_group="",
+        host_pattern="manual_debug_host",
+        current_host="debug-host-without-ui-group",
+        latest_event="Worker details posted without ui_group",
+        worker_command="debug",
+        worker_hostname="demo-worker-02",
+        workflow="ManualDebug",
+    ),
+    DemoWorkspace(
+        name="stale_deletable_workspace",
+        ui_group="omega",
+        host_pattern="nodes_omega",
+        current_host="node-omega-b",
+        latest_event="No worker heartbeat for more than a week",
+        has_mutex=False,
+        stale=True,
+        worker_command="run",
+        worker_hostname="demo-worker-retired",
+        workflow="StaleCleanupDemo",
+    ),
+    DemoWorkspace(
+        name="stale_mutexed_workspace",
+        ui_group="theta",
+        host_pattern="nodes_theta",
+        current_host="node-theta-b",
+        latest_event="Server-side workspace mutex remains after stale worker",
+        stale=True,
+        worker_command="run",
+        worker_hostname="demo-worker-retired",
+        workflow="StaleCleanupDemo",
+    ),
+    DemoWorkspace(
+        name="very_very_long_workspace_name_for_fit_testing_and_demo",
+        ui_group="alpha",
+        host_pattern="nodes_alpha:nodes_beta:nodes_gamma",
+        current_host="node-with-a-very-long-current-host-name-for-layout-testing",
+        latest_event="Locking remote host",
+        build="50327",
+        workflow="LongTextFitCheck",
+    ),
+]
+
+
+def seed_development_workspaces(state: State) -> bool:
+    """Seeds mock dashboard data for local development when state is empty."""
+    if state.workspaces:
+        return False
+
+    now = datetime.now(UTC)
+    demo_connected_until = now + timedelta(hours=1)
+    for index, example in enumerate(DEMO_WORKSPACES):
+        worker_limit = example.worker_limit or example.current_host or "all"
+        last_seen = (
+            now - timedelta(days=8, seconds=index)
+            if example.stale
+            else demo_connected_until - timedelta(seconds=index)
+        )
+        events = [
+            WorkspaceEvent(
+                severity="info",
+                message="Workspace client details posted",
+                create_time=now - timedelta(seconds=120 + index),
+            ),
+            WorkspaceEvent(
+                severity="info",
+                message=(
+                    f"Derived ui_group={example.ui_group or 'Ungrouped'} "
+                    f"from current_host={example.current_host or 'unknown'}"
+                ),
+                create_time=now - timedelta(seconds=60 + index),
+            ),
+            WorkspaceEvent(
+                severity=example.severity,
+                message=example.latest_event,
+                create_time=now - timedelta(seconds=index),
+            ),
+        ]
+        events.extend(
+            WorkspaceEvent(
+                severity="info",
+                message=f"Demo history line {event_index + 1} for {example.current_host}",
+                create_time=now - timedelta(seconds=180 + index + event_index),
+            )
+            for event_index in range(example.extra_events)
+        )
+        state.workspaces[example.name] = WorkspaceState(
+            details=WorkspaceDetails(
+                current_host=example.current_host,
+                deployment_number=example.build,
+                deployment_user="demo-user",
+                host_pattern=example.host_pattern,
+                ui_group=example.ui_group,
+                worker_command=example.worker_command,
+                worker_hostname=example.worker_hostname,
+                worker_limit=worker_limit,
+                worker_username="demo",
+                workflow=example.workflow,
+            ),
+            events=events,
+            last_seen=last_seen,
+            semaphores=WorkspaceSemaphores(caught=example.caught, has_mutex=example.has_mutex),
+        )
+    return True

--- a/src/boardwalkd/protocol.py
+++ b/src/boardwalkd/protocol.py
@@ -59,6 +59,7 @@ class ApiLoginMessage(ProtocolBaseModel):
 class WorkspaceDetails(ProtocolBaseModel):
     """Model for basic workspace details from workers"""
 
+    current_host: str = ""
     deployment_name: str = ""
     deployment_number: str = ""
     deployment_tag: str = ""
@@ -67,6 +68,7 @@ class WorkspaceDetails(ProtocolBaseModel):
     deployment_user_email: str = ""
     deployment_user_id: str = ""
     host_pattern: str = ""
+    ui_group: str = ""
     workflow: str = ""
     worker_command: str = ""
     worker_hostname: str = ""

--- a/src/boardwalkd/protocol.py
+++ b/src/boardwalkd/protocol.py
@@ -13,6 +13,7 @@ import webbrowser
 from collections import deque
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlencode, urljoin, urlparse
 
 import click
@@ -75,7 +76,7 @@ class WorkspaceDetails(ProtocolBaseModel):
     worker_limit: str = ""
     worker_username: str = ""
 
-    def __init__(self, **kwargs: str):
+    def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
 
     @field_validator("deployment_url")
@@ -95,7 +96,7 @@ class WorkspaceEvent(ProtocolBaseModel):
     create_time: datetime | None = None
     received_time: datetime | None = None
 
-    def __init__(self, **kwargs: str):
+    def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
         if not self.create_time:
             self.create_time: datetime | None = datetime.now(UTC)

--- a/src/boardwalkd/protocol.py
+++ b/src/boardwalkd/protocol.py
@@ -13,7 +13,6 @@ import webbrowser
 from collections import deque
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
 from urllib.parse import urlencode, urljoin, urlparse
 
 import click
@@ -76,7 +75,7 @@ class WorkspaceDetails(ProtocolBaseModel):
     worker_limit: str = ""
     worker_username: str = ""
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, **kwargs: str):
         super().__init__(**kwargs)
 
     @field_validator("deployment_url")
@@ -96,7 +95,7 @@ class WorkspaceEvent(ProtocolBaseModel):
     create_time: datetime | None = None
     received_time: datetime | None = None
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, **kwargs: str | datetime | None):
         super().__init__(**kwargs)
         if not self.create_time:
             self.create_time: datetime | None = datetime.now(UTC)

--- a/src/boardwalkd/server.py
+++ b/src/boardwalkd/server.py
@@ -1120,7 +1120,6 @@ def make_app(
     auth_login_slack_notify: bool,
     auth_method: str,
     develop: bool,
-    develop_snapshot_path: str | None,
     host_header_pattern: re.Pattern[str],
     owner: str,
     slack_bot_token: str | None,
@@ -1129,6 +1128,8 @@ def make_app(
     slack_webhook_url: str,
     url: str,
     workspace_status_json: bool,
+    develop_snapshot_path: str | None = None,
+    demo: bool = False,
     theme_static_path: str | None = None,
     theme_css_url: str = "",
     theme_logo_url: str = "",
@@ -1171,12 +1172,14 @@ def make_app(
     }
     if develop:
         settings["debug"] = True
-        if develop_snapshot_path:
-            seeded = seed_snapshot_workspaces(state, develop_snapshot_path)
-        else:
-            seeded = seed_development_workspaces(state)
-        if seeded:
-            state.flush()
+    if develop_snapshot_path:
+        seeded = seed_snapshot_workspaces(state, develop_snapshot_path)
+    elif demo:
+        seeded = seed_development_workspaces(state)
+    else:
+        seeded = False
+    if seeded:
+        state.flush()
 
     # Set-up authentication
     if auth_method != "anonymous":
@@ -1297,7 +1300,6 @@ async def run(
     auth_login_slack_notify: bool,
     auth_method: str,
     develop: bool,
-    develop_snapshot_path: str | None,
     host_header_pattern: re.Pattern[str],
     owner: str,
     port_number: int | None,
@@ -1312,6 +1314,8 @@ async def run(
     slack_slash_command_prefix: str,
     url: str,
     workspace_status_json: bool,
+    develop_snapshot_path: str | None = None,
+    demo: bool = False,
     theme_static_path: str | None = None,
     theme_css_url: str = "",
     theme_logo_url: str = "",
@@ -1328,7 +1332,6 @@ async def run(
         auth_login_slack_notify=auth_login_slack_notify,
         auth_method=auth_method,
         develop=develop,
-        develop_snapshot_path=develop_snapshot_path,
         host_header_pattern=host_header_pattern,
         owner=owner,
         slack_bot_token=slack_bot_token,
@@ -1337,6 +1340,8 @@ async def run(
         slack_webhook_url=slack_webhook_url,
         url=url,
         workspace_status_json=workspace_status_json,
+        develop_snapshot_path=develop_snapshot_path,
+        demo=demo,
         theme_static_path=theme_static_path,
         theme_css_url=theme_css_url,
         theme_logo_url=theme_logo_url,

--- a/src/boardwalkd/server.py
+++ b/src/boardwalkd/server.py
@@ -15,7 +15,7 @@ import ssl
 import string
 from collections import deque
 from collections.abc import Callable
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from importlib.metadata import version as lib_version
 from pathlib import Path
 from typing import Any
@@ -42,8 +42,19 @@ from boardwalkd.auth_prompts import (
     set_auth_prompt,
 )
 from boardwalkd.broadcast import handle_auth_login_broadcast, handle_slack_broadcast, slack_user_mention_for_email
+from boardwalkd.dashboard import (
+    DashboardFilters,
+    action_url,
+    build_dashboard,
+    canonical_url,
+    partial_url,
+    query_url,
+    sort_url,
+)
+from boardwalkd.demo import seed_development_workspaces
 from boardwalkd.protocol import AUTH_LOGIN_CONTEXT_FIELDS, ApiLoginMessage, WorkspaceDetails, WorkspaceEvent
 from boardwalkd.slack_error_advice import SlackErrorAdviceRule, matching_error_advice
+from boardwalkd.snapshot import seed_snapshot_workspaces
 from boardwalkd.state import User, WorkspaceState, load_state, valid_user_roles
 from boardwalkd.utils import is_workspace_active
 
@@ -124,6 +135,46 @@ def ui_method_sort_events_by_date(handler: UIBaseHandler, events: deque[Workspac
     # with older `boardwalk` client versions
     key: Callable[[WorkspaceEvent], datetime] = lambda x: x.create_time.replace(tzinfo=UTC)  # type: ignore # noqa: E731
     return sorted(events, key=key, reverse=True)
+
+
+def dashboard_request_context(handler: UIBaseHandler) -> tuple[DashboardFilters, bool]:
+    try:
+        edit: str | int | bool = handler.get_argument("edit", default=0)  # type: ignore
+        edit = strtobool(edit)  # type: ignore
+    except (AttributeError, ValueError):
+        edit = 0
+    filters = DashboardFilters(
+        group=handler.get_query_argument("group", default="All"),
+        search=handler.get_query_argument("search", default=""),
+        status=handler.get_query_argument("status", default="all"),
+        source=handler.get_query_argument("source", default="all"),
+        sort=handler.get_query_argument("sort", default="default"),
+        direction=handler.get_query_argument("direction", default="asc"),
+    )
+    return filters, bool(edit)
+
+
+def render_workspaces_fragment(handler: UIBaseHandler, filters: DashboardFilters, edit: bool):
+    dashboard = build_dashboard(
+        state.workspaces,
+        filters,
+        jenkins_job_url=handler.settings.get("jenkins_job_url", ""),
+        error_advice_rules=handler.settings.get("slack_error_advice_rules", []),
+    )
+    return handler.render(
+        "index_workspace.html",
+        dashboard=dashboard,
+        workspaces=state.workspaces,
+        edit=edit,
+        auth_prompts=list(active_auth_prompts.values()),
+        auth_prompts_by_workspace=prompts_by_workspace(),
+        action_url=action_url,
+        canonical_url=canonical_url,
+        partial_url=partial_url,
+        query_url=query_url,
+        sort_url=sort_url,
+        orphan_auth_prompts=orphan_auth_prompts(state.workspaces.keys()),
+    )
 
 
 class AdminUIBaseHandler(UIBaseHandler):
@@ -380,12 +431,14 @@ class IndexHandler(UIBaseHandler):
 
     @tornado.web.authenticated
     def get(self):
-        try:
-            edit: str | int | bool = self.get_argument("edit", default=0)  # type: ignore
-            edit = strtobool(edit)  # type: ignore
-        except (AttributeError, ValueError):
-            edit = 0
-        return self.render("index.html", title="Index", workspaces=state.workspaces, edit=edit)
+        filters, edit = dashboard_request_context(self)
+        return self.render(
+            "index.html",
+            title="Index",
+            workspaces=state.workspaces,
+            workspaces_url=partial_url(filters, edit=edit),
+            edit=edit,
+        )
 
 
 class WorkspaceCatchHandler(UIBaseHandler):
@@ -393,6 +446,7 @@ class WorkspaceCatchHandler(UIBaseHandler):
 
     @tornado.web.authenticated
     def post(self, workspace: str):
+        filters, edit = dashboard_request_context(self)
         try:
             state.workspaces[workspace].semaphores.caught = True
         except KeyError:
@@ -403,10 +457,11 @@ class WorkspaceCatchHandler(UIBaseHandler):
         event = WorkspaceEvent(severity="info", message=f"Workspace caught by {cur_user}")
         internal_workspace_event(workspace, event)
 
-        return self.render("index_workspace_release.html", workspace_name=workspace)
+        return render_workspaces_fragment(self, filters, edit)
 
     @tornado.web.authenticated
     def delete(self, workspace: str):
+        filters, edit = dashboard_request_context(self)
         try:
             state.workspaces[workspace].semaphores.caught = False
         except KeyError:
@@ -417,7 +472,7 @@ class WorkspaceCatchHandler(UIBaseHandler):
         event = WorkspaceEvent(severity="info", message=f"Workspace released by {cur_user}")
         internal_workspace_event(workspace, event)
 
-        return self.render("index_workspace_catch.html", workspace_name=workspace)
+        return render_workspaces_fragment(self, filters, edit)
 
 
 class WorkspaceRemoteStateClearHandler(UIBaseHandler):
@@ -504,21 +559,28 @@ class WorkspaceEventsTableHandler(UIBaseHandler):
         return self.render("workspace_events_table.html", workspace=workspace)
 
 
+def workspace_has_recent_heartbeat(workspace: WorkspaceState, now: datetime | None = None) -> bool:
+    if not workspace.last_seen:
+        return False
+    delta = (now or datetime.now(UTC)) - workspace.last_seen.replace(tzinfo=UTC)
+    return delta.total_seconds() < 10
+
+
 class WorkspaceMutexHandler(UIBaseHandler):
     """Handles mutex requests for workspaces from the UI"""
 
     @tornado.web.authenticated
     def delete(self, workspace: str):
+        filters, edit = dashboard_request_context(self)
         try:
             # If the host is possibly still connected we will not delete the
             # mutex. Workspaces should send a heartbeat every 5 seconds
-            delta: timedelta = datetime.now(UTC) - state.workspaces[workspace].last_seen.replace(tzinfo=UTC)  # type: ignore
-            if delta.total_seconds() < 10:
+            workspace_state = state.workspaces[workspace]
+            if workspace_has_recent_heartbeat(workspace_state):
                 return self.send_error(412)
-            state.workspaces[workspace].semaphores.has_mutex = False
+            workspace_state.semaphores.has_mutex = False
             state.flush()
-            self.set_header(name="HX-Refresh", value="true")
-            return
+            return render_workspaces_fragment(self, filters, edit)
         except KeyError:
             return self.send_error(404)
 
@@ -528,14 +590,14 @@ class WorkspaceDeleteHandler(UIBaseHandler):
 
     @tornado.web.authenticated
     def post(self, workspace: str):
+        filters, edit = dashboard_request_context(self)
         try:
             # If there is a mutex on the workspace we will not delete it
             if state.workspaces[workspace].semaphores.has_mutex:
                 return self.send_error(412)
             del state.workspaces[workspace]
             state.flush()
-            self.set_header(name="HX-Refresh", value="true")
-            return
+            return render_workspaces_fragment(self, filters, edit)
         except KeyError:
             return self.send_error(404)
 
@@ -545,19 +607,10 @@ class WorkspacesHandler(UIBaseHandler):
 
     @tornado.web.authenticated
     def get(self):
-        try:
-            edit: str | int | bool = self.get_argument("edit", default=0)  # type: ignore
-            edit = strtobool(edit)  # type: ignore
-        except (AttributeError, ValueError):
-            edit = 0
-        return self.render(
-            "index_workspace.html",
-            workspaces=state.workspaces,
-            edit=edit,
-            auth_prompts=list(active_auth_prompts.values()),
-            auth_prompts_by_workspace=prompts_by_workspace(),
-            orphan_auth_prompts=orphan_auth_prompts(state.workspaces.keys()),
-        )
+        filters, edit = dashboard_request_context(self)
+        if self.get_query_argument("push_url", default="") == "1":
+            self.set_header(name="HX-Push-Url", value=canonical_url(filters, edit=edit))
+        return render_workspaces_fragment(self, filters, edit)
 
 
 """
@@ -627,12 +680,17 @@ def auth_login_context_from_request(handler: tornado.web.RequestHandler) -> dict
 async def notify_auth_login(login_url: str, auth_context: dict[str, str], settings: dict[str, Any]):
     """Posts an auth-login notification without interrupting the websocket flow."""
     try:
+        slack_user_mention = await slack_user_mention_for_email(
+            auth_context.get("deployment_user_email"),
+            settings.get("slack_bot_token"),
+        )
         await handle_auth_login_broadcast(
             login_url=login_url,
             auth_context=auth_context,
             webhook_url=settings.get("slack_webhook_url"),
             error_webhook_url=settings.get("slack_error_webhook_url"),
             server_url=settings["url"].geturl(),
+            slack_user_mention=slack_user_mention,
         )
     except Exception as e:
         app_log.error(f"Could not send auth login Slack notification: {e}")
@@ -1048,6 +1106,7 @@ def make_app(
     auth_login_slack_notify: bool,
     auth_method: str,
     develop: bool,
+    develop_snapshot_path: str | None,
     host_header_pattern: re.Pattern[str],
     owner: str,
     slack_bot_token: str | None,
@@ -1056,6 +1115,12 @@ def make_app(
     slack_webhook_url: str,
     url: str,
     workspace_status_json: bool,
+    theme_static_path: str | None = None,
+    theme_css_url: str = "",
+    theme_logo_url: str = "",
+    theme_logo_alt: str = "",
+    theme_brand_name: str = "Boardwalk",
+    jenkins_job_url: str = "",
 ) -> tornado.web.Application:
     """Builds the tornado application object"""
     handlers: list[tornado.web.OutputTransform] = []
@@ -1073,12 +1138,17 @@ def make_app(
         "slack_error_webhook_url": slack_error_webhook_url,
         "static_path": module_dir.joinpath("static"),
         "template_path": module_dir.joinpath("templates"),
+        "theme_css_url": theme_css_url,
+        "theme_logo_url": theme_logo_url,
+        "theme_logo_alt": theme_logo_alt,
+        "theme_brand_name": theme_brand_name or "Boardwalk",
         "ui_methods": {
             "secondsdelta": ui_method_secondsdelta,
             "server_version": ui_method_server_version,
             "sha256": ui_method_sha256,
             "sort_events_by_date": ui_method_sort_events_by_date,
         },
+        "jenkins_job_url": jenkins_job_url,
         "workspace_status_json": workspace_status_json,
         "url": urlparse(url),
         "websocket_ping_interval": 10,
@@ -1087,6 +1157,12 @@ def make_app(
     }
     if develop:
         settings["debug"] = True
+        if develop_snapshot_path:
+            seeded = seed_snapshot_workspaces(state, develop_snapshot_path)
+        else:
+            seeded = seed_development_workspaces(state)
+        if seeded:
+            state.flush()
 
     # Set-up authentication
     if auth_method != "anonymous":
@@ -1117,6 +1193,9 @@ def make_app(
             handlers.append((r"/auth/login", GoogleOAuth2LoginHandler))  # type: ignore
         case _:
             raise BoardwalkException(f"auth_method {auth_method} is not supported")
+
+    if theme_static_path:
+        handlers.append((r"/theme-static/(.*)", tornado.web.StaticFileHandler, {"path": theme_static_path}))  # type: ignore
 
     # Set-up all the main handlers
     handlers.extend(
@@ -1204,6 +1283,7 @@ async def run(
     auth_login_slack_notify: bool,
     auth_method: str,
     develop: bool,
+    develop_snapshot_path: str | None,
     host_header_pattern: re.Pattern[str],
     owner: str,
     port_number: int | None,
@@ -1218,6 +1298,12 @@ async def run(
     slack_slash_command_prefix: str,
     url: str,
     workspace_status_json: bool,
+    theme_static_path: str | None = None,
+    theme_css_url: str = "",
+    theme_logo_url: str = "",
+    theme_logo_alt: str = "",
+    theme_brand_name: str = "Boardwalk",
+    jenkins_job_url: str = "",
 ):
     """Starts the tornado server and IO loop"""
     global state
@@ -1228,6 +1314,7 @@ async def run(
         auth_login_slack_notify=auth_login_slack_notify,
         auth_method=auth_method,
         develop=develop,
+        develop_snapshot_path=develop_snapshot_path,
         host_header_pattern=host_header_pattern,
         owner=owner,
         slack_bot_token=slack_bot_token,
@@ -1236,6 +1323,12 @@ async def run(
         slack_webhook_url=slack_webhook_url,
         url=url,
         workspace_status_json=workspace_status_json,
+        theme_static_path=theme_static_path,
+        theme_css_url=theme_css_url,
+        theme_logo_url=theme_logo_url,
+        theme_logo_alt=theme_logo_alt,
+        theme_brand_name=theme_brand_name,
+        jenkins_job_url=jenkins_job_url,
     )
 
     if port_number is not None:

--- a/src/boardwalkd/server.py
+++ b/src/boardwalkd/server.py
@@ -562,13 +562,6 @@ class WorkspaceEventsTableHandler(UIBaseHandler):
         return self.render("workspace_events_table.html", workspace=workspace)
 
 
-def workspace_has_recent_heartbeat(workspace: WorkspaceState, now: datetime | None = None) -> bool:
-    if not workspace.last_seen:
-        return False
-    delta = (now or datetime.now(UTC)) - workspace.last_seen.replace(tzinfo=UTC)
-    return delta.total_seconds() < 10
-
-
 class WorkspaceMutexHandler(UIBaseHandler):
     """Handles mutex requests for workspaces from the UI"""
 
@@ -579,7 +572,7 @@ class WorkspaceMutexHandler(UIBaseHandler):
             # If the host is possibly still connected we will not delete the
             # mutex. Workspaces should send a heartbeat every 5 seconds
             workspace_state = state.workspaces[workspace]
-            if workspace_has_recent_heartbeat(workspace_state):
+            if is_workspace_active(workspace):
                 return self.send_error(412)
             workspace_state.semaphores.has_mutex = False
             state.flush()
@@ -923,6 +916,9 @@ class WorkspaceRemoteMutexClearApiHandler(APIBaseHandler):
             return self.send_error(404)
 
 
+# These fields decide whether a details POST should create a log event. current_host
+# and ui_group intentionally update state silently because workers POST details on
+# every host iteration, and logging each update would bury the useful event stream.
 WORKSPACE_CLIENT_DETAILS_EVENT_FIELDS = (
     "workflow",
     "worker_username",
@@ -1199,6 +1195,9 @@ def make_app(
     }
     if develop:
         settings["debug"] = True
+    # Snapshot/demo seeding is development-only fixture data. A snapshot wins over
+    # demo rows so local replay of real-shaped state is never mixed with synthetic
+    # demo workspaces.
     if develop_snapshot_path:
         seeded = seed_snapshot_workspaces(state, develop_snapshot_path)
     elif demo:

--- a/src/boardwalkd/server.py
+++ b/src/boardwalkd/server.py
@@ -923,6 +923,38 @@ class WorkspaceRemoteMutexClearApiHandler(APIBaseHandler):
             return self.send_error(404)
 
 
+WORKSPACE_CLIENT_DETAILS_EVENT_FIELDS = (
+    "workflow",
+    "worker_username",
+    "worker_hostname",
+    "host_pattern",
+    "worker_limit",
+    "worker_command",
+)
+
+
+def workspace_client_details_event_should_log(
+    old_details: WorkspaceDetails | None,
+    new_details: WorkspaceDetails,
+) -> bool:
+    if old_details is None:
+        return True
+    return any(
+        getattr(old_details, field) != getattr(new_details, field) for field in WORKSPACE_CLIENT_DETAILS_EVENT_FIELDS
+    )
+
+
+def workspace_client_details_event_message(workspace_details: WorkspaceDetails) -> str:
+    return (
+        "Workspace client details:"
+        f" Workflow: {workspace_details.workflow},"
+        f" Worker: {workspace_details.worker_username}@{workspace_details.worker_hostname},"
+        f" Host Pattern: {workspace_details.host_pattern},"
+        f" Limit Pattern: {workspace_details.worker_limit if workspace_details.worker_limit else '<unknown>'},"
+        f" Command: {workspace_details.worker_command}"
+    )
+
+
 class WorkspaceDetailsApiHandler(APIBaseHandler):
     """Handles getting and updating WorkspaceDetails for workspaces"""
 
@@ -946,6 +978,10 @@ class WorkspaceDetailsApiHandler(APIBaseHandler):
             app_log.error(e)
             return self.send_error(422)
 
+        existing_workspace = state.workspaces.get(workspace)
+        existing_details = existing_workspace.details if existing_workspace else None
+        log_client_details_event = workspace_client_details_event_should_log(existing_details, new_details)
+
         try:
             state.workspaces[workspace].details = new_details
         except KeyError:
@@ -954,18 +990,9 @@ class WorkspaceDetailsApiHandler(APIBaseHandler):
         state.workspaces[workspace].last_seen = datetime.now(UTC)
         state.flush()
 
-        # Log the updated details to the events table
-        workspace_details = state.workspaces[workspace].details
-        message = (
-            "Workspace client details:"
-            f" Workflow: {workspace_details.workflow},"
-            f" Worker: {workspace_details.worker_username}@{workspace_details.worker_hostname},"
-            f" Host Pattern: {workspace_details.host_pattern},"
-            f" Limit Pattern: {workspace_details.worker_limit if workspace_details.worker_limit else '<unknown>'},"
-            f" Command: {workspace_details.worker_command}"
-        )
-        event = WorkspaceEvent(severity="info", message=message)
-        internal_workspace_event(workspace, event)
+        if log_client_details_event:
+            event = WorkspaceEvent(severity="info", message=workspace_client_details_event_message(new_details))
+            internal_workspace_event(workspace, event)
 
 
 class WorkspaceHeartbeatApiHandler(APIBaseHandler):

--- a/src/boardwalkd/snapshot.py
+++ b/src/boardwalkd/snapshot.py
@@ -96,6 +96,8 @@ def _inventory_labels_for_pattern(pattern: Any, inventory: Mapping[str, Any] | N
     return labels
 
 
+# Group derivation here is only for sanitized local replay. Production grouping
+# comes from boardwalk clients posting WorkspaceDetails.ui_group.
 def _derived_group(details: Mapping[str, Any], inventory: Mapping[str, Any] | None = None) -> str:
     ui_group = str(details.get("ui_group") or "")
     if ui_group:

--- a/src/boardwalkd/snapshot.py
+++ b/src/boardwalkd/snapshot.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from boardwalkd.protocol import WorkspaceDetails, WorkspaceEvent, WorkspaceSemaphores
+from boardwalkd.state import State, WorkspaceState
+
+SNAPSHOT_FORMAT = "boardwalkd-status-snapshot-v1"
+GROUP_LABEL_PATTERN = re.compile(r"^[a-z][a-z0-9-]*_(?P<group>[a-z][a-z0-9-]*)$")
+
+
+def _normalized_now(now: datetime | None = None) -> datetime:
+    return (now or datetime.now(UTC)).replace(tzinfo=UTC)
+
+
+def _parse_time(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value)).replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def _safe_label(value: str, fallback: str = "ungrouped") -> str:
+    label = re.sub(r"[^a-zA-Z0-9_]+", "_", value.strip()).strip("_").lower()
+    return label or fallback
+
+
+def _group_from_pattern_part(value: str) -> str:
+    match = GROUP_LABEL_PATTERN.match(value.lower().strip())
+    return match.group("group") if match else ""
+
+
+def _group_labels(value: Any) -> list[str]:
+    if not value:
+        return []
+    labels = []
+    for part in str(value).split(":"):
+        label = _group_from_pattern_part(part)
+        if label and label not in labels:
+            labels.append(label)
+    return labels
+
+
+def load_inventory_context(path: str | Path | None) -> Mapping[str, Any] | None:
+    if path is None:
+        return None
+    return json.loads(Path(path).read_text())
+
+
+def _inventory_parents(inventory: Mapping[str, Any]) -> dict[str, set[str]]:
+    parents: dict[str, set[str]] = {}
+    for group, body in inventory.items():
+        if group == "_meta" or not isinstance(body, Mapping):
+            continue
+        for child in body.get("children", []) or []:
+            parents.setdefault(str(child), set()).add(str(group))
+    return parents
+
+
+def _inventory_labels_for_group(
+    group: str,
+    parents: Mapping[str, set[str]],
+    seen: set[str] | None = None,
+) -> set[str]:
+    match = GROUP_LABEL_PATTERN.match(group)
+    if match:
+        return {match.group("group")}
+    seen = seen or set()
+    if group in seen:
+        return set()
+    seen.add(group)
+    labels: set[str] = set()
+    for parent in parents.get(group, set()):
+        labels.update(_inventory_labels_for_group(parent, parents, seen))
+    return labels
+
+
+def _inventory_labels_for_pattern(pattern: Any, inventory: Mapping[str, Any] | None) -> set[str]:
+    if not pattern or inventory is None:
+        return set()
+    parents = _inventory_parents(inventory)
+    labels: set[str] = set()
+    for raw_part in str(pattern).split(":"):
+        part = raw_part.strip()
+        if not part or part.startswith("!") or part.startswith("&"):
+            continue
+        labels.update(_inventory_labels_for_group(part, parents))
+    return labels
+
+
+def _derived_group(details: Mapping[str, Any], inventory: Mapping[str, Any] | None = None) -> str:
+    ui_group = str(details.get("ui_group") or "")
+    if ui_group:
+        return ui_group
+    current_host_group = _group_from_pattern_part(str(details.get("current_host") or ""))
+    if current_host_group:
+        return current_host_group
+    host_pattern_groups = _group_labels(details.get("host_pattern"))
+    if len(host_pattern_groups) == 1:
+        return host_pattern_groups[0]
+    if len(host_pattern_groups) > 1:
+        return "Multi-group"
+    inventory_groups = _inventory_labels_for_pattern(details.get("host_pattern"), inventory)
+    if len(inventory_groups) == 1:
+        return next(iter(inventory_groups))
+    if len(inventory_groups) > 1:
+        return "Multi-group"
+    return ""
+
+
+def _redacted_pattern(value: Any, group: str, index: int) -> str:
+    if not value:
+        return ""
+    fallback = _safe_label(group)
+    parts = str(value).split(":")
+    labels = [_safe_label(_group_from_pattern_part(part) or group, fallback=fallback) for part in parts]
+    return ":".join(f"pattern-{label}-{index:03d}" for label in labels)
+
+
+def _redacted_details(details: Mapping[str, Any], index: int, inventory: Mapping[str, Any] | None) -> WorkspaceDetails:
+    group = _derived_group(details, inventory=inventory)
+    group_label = _safe_label(group)
+    current_host = str(details.get("current_host") or "")
+    redacted_current_host = f"snapshot-host-{group_label}-{index:03d}" if current_host else ""
+    deployment_number = str(details.get("deployment_number") or "")
+    deployment_url = str(details.get("deployment_url") or "")
+    return WorkspaceDetails(
+        current_host=redacted_current_host,
+        deployment_name=f"snapshot-deployment-{index:03d}" if details.get("deployment_name") else "",
+        deployment_number=f"snapshot-build-{index:03d}" if deployment_number else "",
+        deployment_tag=f"snapshot-tag-{index:03d}" if details.get("deployment_tag") else "",
+        deployment_url=f"https://snapshot.invalid/deployment/{index:03d}/" if deployment_url else "",
+        deployment_user=f"snapshot-user-{index:03d}" if details.get("deployment_user") else "",
+        deployment_user_email=(
+            f"snapshot-user-{index:03d}@example.invalid" if details.get("deployment_user_email") else ""
+        ),
+        deployment_user_id=f"snapshot-user-id-{index:03d}" if details.get("deployment_user_id") else "",
+        host_pattern=_redacted_pattern(details.get("host_pattern"), group, index),
+        ui_group=group,
+        workflow=f"SnapshotWorkflow{index:03d}" if details.get("workflow") else "",
+        worker_command="snapshot run" if details.get("worker_command") else "",
+        worker_hostname=f"snapshot-worker-{group_label}-{index:03d}" if details.get("worker_hostname") else "",
+        worker_limit=(
+            redacted_current_host
+            if details.get("worker_limit") and details.get("worker_limit") == details.get("current_host")
+            else _redacted_pattern(details.get("worker_limit"), group, index)
+        ),
+        worker_username="snapshot-worker" if details.get("worker_username") else "",
+    )
+
+
+def _preserved_details(details: Mapping[str, Any], inventory: Mapping[str, Any] | None) -> WorkspaceDetails:
+    return WorkspaceDetails(
+        current_host=str(details.get("current_host") or ""),
+        deployment_name=str(details.get("deployment_name") or ""),
+        deployment_number=str(details.get("deployment_number") or ""),
+        deployment_tag=str(details.get("deployment_tag") or ""),
+        deployment_url=str(details.get("deployment_url") or ""),
+        deployment_user=str(details.get("deployment_user") or ""),
+        deployment_user_email=str(details.get("deployment_user_email") or ""),
+        deployment_user_id=str(details.get("deployment_user_id") or ""),
+        host_pattern=str(details.get("host_pattern") or ""),
+        ui_group=_derived_group(details, inventory=inventory),
+        workflow=str(details.get("workflow") or ""),
+        worker_command=str(details.get("worker_command") or ""),
+        worker_hostname=str(details.get("worker_hostname") or ""),
+        worker_limit=str(details.get("worker_limit") or ""),
+        worker_username=str(details.get("worker_username") or ""),
+    )
+
+
+def _sanitized_semaphores(value: Mapping[str, Any]) -> WorkspaceSemaphores:
+    return WorkspaceSemaphores(
+        caught=bool(value.get("caught", False)),
+        clear_remote_mutex_requested=bool(value.get("clear_remote_mutex_requested", False)),
+        clear_remote_state_requested=bool(value.get("clear_remote_state_requested", False)),
+        has_mutex=bool(value.get("has_mutex", False)),
+    )
+
+
+def sanitize_status_snapshot(
+    snapshot: Mapping[str, Any],
+    now: datetime | None = None,
+    preserve_identifiers: bool = False,
+    inventory: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a replayable snapshot converted from /api/workspaces/status JSON."""
+    captured_at = _normalized_now(now)
+    sanitized: dict[str, Any] = {
+        "snapshot_format": SNAPSHOT_FORMAT,
+        "captured_at": captured_at.isoformat(),
+        "workspaces": [],
+    }
+    for index, entry in enumerate(snapshot.get("workspaces", []), start=1):
+        details = entry.get("details") or {}
+        semaphores = entry.get("semaphores") or {}
+        group_label = _safe_label(_derived_group(details, inventory=inventory))
+        workspace_details = (
+            _preserved_details(details, inventory=inventory)
+            if preserve_identifiers
+            else _redacted_details(details, index, inventory=inventory)
+        )
+        source_last_seen = _parse_time(entry.get("last_seen"))
+        last_seen_age_seconds = None
+        if source_last_seen is not None:
+            last_seen_age_seconds = max(0, int((captured_at - source_last_seen).total_seconds()))
+        workspace_name = (
+            str(entry.get("name") or f"snapshot_{group_label}_{index:03d}")
+            if preserve_identifiers
+            else f"snapshot_{group_label}_{index:03d}"
+        )
+        sanitized["workspaces"].append(
+            {
+                "name": workspace_name,
+                "details": workspace_details.model_dump(),
+                "semaphores": _sanitized_semaphores(semaphores).model_dump(),
+                "worker_connected": bool(details.get("worker_connected", False)),
+                "last_seen_age_seconds": last_seen_age_seconds,
+            }
+        )
+    return sanitized
+
+
+def load_status_snapshot(path: str | Path, now: datetime | None = None) -> dict[str, Any]:
+    data = json.loads(Path(path).read_text())
+    if data.get("snapshot_format") == SNAPSHOT_FORMAT:
+        return data
+    return sanitize_status_snapshot(data, now=now)
+
+
+def _snapshot_last_seen(entry: Mapping[str, Any], index: int, now: datetime) -> datetime | None:
+    if entry.get("worker_connected"):
+        return now + timedelta(hours=1) - timedelta(seconds=index)
+    age = entry.get("last_seen_age_seconds")
+    if age is None:
+        return None
+    return now - timedelta(seconds=int(age))
+
+
+def seed_snapshot_workspaces(state: State, path: str | Path, now: datetime | None = None) -> bool:
+    """Seed state from a sanitized status snapshot without overwriting existing workspaces."""
+    if state.workspaces:
+        return False
+
+    replay_now = _normalized_now(now)
+    snapshot = load_status_snapshot(path, now=replay_now)
+    for index, entry in enumerate(snapshot.get("workspaces", []), start=1):
+        name = str(entry["name"])
+        details = WorkspaceDetails.model_validate(entry.get("details") or {})
+        semaphores = WorkspaceSemaphores.model_validate(entry.get("semaphores") or {})
+        event = WorkspaceEvent(
+            severity="info",
+            message=(
+                "Sanitized production status snapshot replay: "
+                f"ui_group={details.ui_group or 'Ungrouped'} "
+                f"current_host={details.current_host or 'unknown'}"
+            ),
+            create_time=replay_now - timedelta(seconds=index),
+        )
+        state.workspaces[name] = WorkspaceState(
+            details=details,
+            events=[event],
+            last_seen=_snapshot_last_seen(entry, index, replay_now),
+            semaphores=semaphores,
+        )
+    return True

--- a/src/boardwalkd/snapshot.py
+++ b/src/boardwalkd/snapshot.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections import deque
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -266,7 +267,7 @@ def seed_snapshot_workspaces(state: State, path: str | Path, now: datetime | Non
         )
         state.workspaces[name] = WorkspaceState(
             details=details,
-            events=[event],
+            events=deque([event]),
             last_seen=_snapshot_last_seen(entry, index, replay_now),
             semaphores=semaphores,
         )

--- a/src/boardwalkd/static/boardwalkd.css
+++ b/src/boardwalkd/static/boardwalkd.css
@@ -1,40 +1,1243 @@
-.workspace-details-table td {
-    font-family: monospace;
-    text-align: end;
-    max-width: 290px;
-    word-wrap: break-word;
+* {
+    box-sizing: border-box;
 }
 
-.workspace-events-preview-col {
-    position: relative;
+:root,
+.bw-theme-light {
+    --bw-page: #eef1f5;
+    --bw-bg: #ffffff;
+    --bw-top: #f8fafc;
+    --bw-panel: #e7ebf1;
+    --bw-panel-2: #f3f6fa;
+    --bw-panel-3: #eef2f7;
+    --bw-row-bg: #ffffff;
+    --bw-row-alt: #f7f9fc;
+    --bw-row-hover: #f2f5f9;
+    --bw-fg-1: #1f2735;
+    --bw-fg-2: #5a6478;
+    --bw-fg-3: #8a93a5;
+    --bw-brand: #4b6f8f;
+    --bw-caught: #bf831e;
+    --bw-error: #b84444;
+    --bw-success: #4d7f61;
+    --bw-running: #517da0;
+    --bw-idle: #7c8797;
+    --bw-link: #315f86;
+    --bw-line: #cbd3df;
+    --bw-line-soft: #dfe5ee;
+    --bw-input: #ffffff;
+    --bw-shadow: 0 18px 45px rgba(31, 39, 53, 0.12);
+    --bw-radius: 8px;
+    --bw-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --bw-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 }
 
-.workspace-events-preview-col table {
-    font-family: monospace;
+.bw-theme-dark {
+    --bw-page: #1e2636;
+    --bw-bg: #283143;
+    --bw-top: #2d374b;
+    --bw-panel: #232c3d;
+    --bw-panel-2: #243044;
+    --bw-panel-3: #303b50;
+    --bw-row-bg: #2a3447;
+    --bw-row-alt: #253044;
+    --bw-row-hover: #313d52;
+    --bw-fg-1: #eef2f8;
+    --bw-fg-2: #c4cee0;
+    --bw-fg-3: #98a4ba;
+    --bw-brand: #8bb8d8;
+    --bw-caught: #e3aa46;
+    --bw-error: #e07b7b;
+    --bw-success: #83b88d;
+    --bw-running: #9fc6e4;
+    --bw-idle: #8b97aa;
+    --bw-link: #a9cce8;
+    --bw-line: #45536b;
+    --bw-line-soft: #3a485f;
+    --bw-input: #20293a;
+    --bw-shadow: 0 18px 45px rgba(18, 24, 35, 0.34);
 }
 
-.workspace-events-container {
-    height: 200px;
-    overflow-y: hidden;
-    overflow-x: hidden;
+html,
+body {
+    margin: 0;
+    min-height: 100dvh;
+    background: var(--bw-page);
+    color: var(--bw-fg-1);
+    font-family: var(--bw-sans);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
 }
 
-.workspace-events-table {
-    font-family: monospace;
-    overflow-y: hidden;
-    overflow-x: none;
+body {
+    min-width: 0;
 }
 
-.more-events {
+a {
+    color: var(--bw-link);
+}
+
+[hidden] {
+    display: none !important;
+}
+
+.bw-sr-only {
     position: absolute;
-    bottom: 2px;
-    right: 2px;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
-.workspace-title {
-    word-wrap: break-word;
+.bw-mono {
+    font-family: var(--bw-mono);
 }
 
-.context-underline {
-    border-bottom: 1px dotted #000;
+.bw-topbar {
+    min-height: 58px;
+    padding: 0 24px;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 18px;
+    background: var(--bw-top);
+    border-bottom: 1px solid var(--bw-line);
+}
+
+.bw-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+    color: var(--bw-fg-1);
+    font-size: 15px;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.bw-brand:hover {
+    color: var(--bw-fg-1);
+}
+
+.bw-brand-mark {
+    width: 30px;
+    height: 30px;
+    flex: 0 0 30px;
+    border-radius: var(--bw-radius);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    object-fit: contain;
+}
+
+.bw-brand-mark-text {
+    background: var(--bw-brand);
+    color: var(--bw-bg);
+    font-weight: 800;
+}
+
+.bw-version {
+    color: var(--bw-fg-3);
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.bw-nav {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+}
+
+.bw-nav-link {
+    min-height: 32px;
+    padding: 0 10px;
+    display: inline-flex;
+    align-items: center;
+    border-radius: var(--bw-radius);
+    color: var(--bw-fg-2);
+    font-size: 12px;
+    font-weight: 650;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.bw-nav-link:hover {
+    background: var(--bw-panel-3);
+    color: var(--bw-fg-1);
+}
+
+.bw-theme-toggle {
+    position: relative;
+    width: 64px;
+    height: 30px;
+    padding: 0;
+    display: inline-grid;
+    grid-template-columns: 1fr 1fr;
+    align-items: center;
+    justify-items: center;
+    overflow: hidden;
+    border: 1px solid var(--bw-line);
+    border-radius: 999px;
+    background: var(--bw-panel-3);
+    cursor: pointer;
+    transition: background 140ms ease, border-color 140ms ease;
+}
+
+.bw-theme-toggle:hover {
+    background: var(--bw-row-hover);
+}
+
+.bw-theme-toggle-icon {
+    position: relative;
+    z-index: 1;
+    color: var(--bw-fg-3);
+    font-size: 13px;
+    font-weight: 800;
+    line-height: 1;
+    transition: color 140ms ease;
+}
+
+.bw-theme-light .bw-theme-toggle-icon-light,
+.bw-theme-dark .bw-theme-toggle-icon-dark {
+    color: var(--bw-page);
+}
+
+.bw-theme-toggle-thumb {
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 28px;
+    height: 24px;
+    border-radius: 999px;
+    background: var(--bw-brand);
+    box-shadow: 0 1px 4px rgba(31, 39, 53, 0.28);
+    transition: transform 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.bw-theme-dark .bw-theme-toggle-thumb {
+    transform: translateX(30px);
+}
+
+.bw-app {
+    max-width: 1280px;
+    margin: 24px auto 36px;
+    padding: 0 20px;
+}
+
+.bw-frame {
+    min-height: 240px;
+    overflow: hidden;
+    background: var(--bw-bg);
+    border: 1px solid var(--bw-line);
+    border-radius: var(--bw-radius);
+    box-shadow: var(--bw-shadow);
+}
+
+.bw-tabs {
+    min-height: 52px;
+    padding: 12px 18px 0;
+    display: flex;
+    gap: 4px;
+    overflow-x: auto;
+    background: var(--bw-panel);
+    scrollbar-width: thin;
+}
+
+.bw-tab {
+    min-height: 40px;
+    padding: 0 14px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    border: 1px solid transparent;
+    border-bottom: 0;
+    border-radius: var(--bw-radius) var(--bw-radius) 0 0;
+    color: var(--bw-fg-2);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.bw-tab:hover {
+    color: var(--bw-fg-1);
+    background: rgba(127, 139, 160, 0.14);
+}
+
+.bw-tab.is-active {
+    background: var(--bw-row-bg);
+    border-color: var(--bw-line);
+    color: var(--bw-brand);
+    box-shadow: inset 0 3px 0 var(--bw-brand);
+}
+
+.bw-tab-count {
+    color: var(--bw-fg-3);
+    font-size: 11px;
+    font-weight: 650;
+}
+
+.bw-filterbar {
+    min-height: 72px;
+    padding: 12px 18px;
+    display: grid;
+    grid-template-columns: minmax(320px, 1fr) minmax(150px, auto) minmax(150px, auto) auto;
+    gap: 12px;
+    align-items: end;
+    background: var(--bw-row-bg);
+    border-top: 1px solid var(--bw-line);
+    border-bottom: 1px solid var(--bw-line);
+}
+
+.bw-search-form {
+    display: grid;
+    grid-template-columns: minmax(220px, 1fr) auto;
+    gap: 10px;
+    align-items: end;
+    min-width: 0;
+}
+
+.bw-select-form {
+    min-width: 0;
+}
+
+.bw-filter-actions {
+    display: flex;
+    justify-content: flex-end;
+    align-items: end;
+    min-width: 0;
+}
+
+.bw-field {
+    display: grid;
+    gap: 5px;
+    min-width: 0;
+    margin: 0;
+}
+
+.bw-field > span {
+    color: var(--bw-fg-3);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0;
+    line-height: 1;
+}
+
+.bw-input,
+.bw-select {
+    width: 100%;
+    height: 38px;
+    min-width: 0;
+    padding: 0 12px;
+    border: 1px solid var(--bw-line);
+    border-radius: var(--bw-radius);
+    background: var(--bw-input);
+    color: var(--bw-fg-1);
+    font: inherit;
+    font-size: 12px;
+}
+
+.bw-input::placeholder {
+    color: var(--bw-fg-3);
+}
+
+.bw-input:focus,
+.bw-select:focus,
+.bw-button:focus,
+.bw-expand:focus,
+.bw-theme-toggle:focus {
+    outline: none;
+    border-color: var(--bw-brand);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--bw-brand) 22%, transparent);
+}
+
+.bw-button {
+    min-height: 32px;
+    padding: 0 12px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    border: 1px solid var(--bw-line);
+    border-radius: var(--bw-radius);
+    background: var(--bw-panel-3);
+    color: var(--bw-fg-1);
+    font: inherit;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-decoration: none;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
+}
+
+.bw-button:hover {
+    background: var(--bw-row-hover);
+}
+
+.bw-button:active {
+    transform: translateY(1px);
+}
+
+.bw-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+    transform: none;
+}
+
+.bw-button-primary {
+    min-width: 78px;
+    background: var(--bw-brand);
+    border-color: var(--bw-brand);
+    color: var(--bw-bg);
+}
+
+.bw-search-form .bw-button-primary {
+    height: 38px;
+}
+
+.bw-button-primary:hover {
+    background: color-mix(in srgb, var(--bw-brand) 88%, var(--bw-fg-1));
+}
+
+.bw-button-catch {
+    border-color: color-mix(in srgb, var(--bw-caught) 54%, var(--bw-line));
+    background: color-mix(in srgb, var(--bw-caught) 16%, transparent);
+    color: var(--bw-fg-1);
+}
+
+.bw-button-release {
+    border-color: color-mix(in srgb, var(--bw-caught) 62%, var(--bw-line));
+    background: color-mix(in srgb, var(--bw-caught) 26%, transparent);
+    color: var(--bw-fg-1);
+}
+
+.bw-button-secondary {
+    background: transparent;
+    color: var(--bw-fg-2);
+}
+
+.bw-button-danger {
+    border-color: color-mix(in srgb, var(--bw-error) 70%, var(--bw-line));
+    background: color-mix(in srgb, var(--bw-error) 14%, transparent);
+    color: var(--bw-fg-1);
+}
+
+.bw-notice {
+    padding: 12px 18px;
+    display: grid;
+    gap: 8px;
+    background: color-mix(in srgb, var(--bw-caught) 11%, var(--bw-row-bg));
+    border-bottom: 1px solid var(--bw-line);
+}
+
+.bw-notice-title {
+    color: var(--bw-fg-1);
+    font-size: 12px;
+    font-weight: 750;
+}
+
+.bw-notice-row {
+    min-height: 34px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+    color: var(--bw-fg-2);
+    font-size: 12px;
+}
+
+.bw-lanes {
+    display: grid;
+    gap: 0;
+    background: var(--bw-row-bg);
+}
+
+.bw-lane {
+    display: grid;
+    background: var(--bw-row-bg);
+    border-bottom: 1px solid var(--bw-line);
+}
+
+.bw-lane:last-child {
+    border-bottom: 0;
+}
+
+.bw-lane-header {
+    min-height: 42px;
+    padding: 0 18px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    background: var(--bw-panel-2);
+    border-bottom: 1px solid var(--bw-line);
+}
+
+.bw-lane-header h2 {
+    margin: 0;
+    color: var(--bw-fg-1);
+    font-size: 13px;
+    font-weight: 800;
+    letter-spacing: 0;
+}
+
+.bw-lane-header span {
+    color: var(--bw-fg-3);
+    font-size: 11px;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.bw-lane-active .bw-lane-header {
+    box-shadow: inset 3px 0 0 var(--bw-running);
+}
+
+.bw-lane-attention .bw-lane-header {
+    box-shadow: inset 3px 0 0 var(--bw-caught);
+}
+
+.bw-table {
+    display: grid;
+    background: var(--bw-row-bg);
+}
+
+.bw-head,
+.bw-row {
+    display: grid;
+    grid-template-columns:
+        minmax(280px, 1.6fr)
+        minmax(128px, 0.52fr)
+        minmax(380px, 1.75fr)
+        minmax(112px, 0.46fr)
+        minmax(92px, 0.42fr)
+        minmax(126px, auto);
+    gap: 12px;
+    align-items: center;
+}
+
+.bw-head {
+    min-height: 38px;
+    padding: 0 18px;
+    background: var(--bw-row-alt);
+    border-bottom: 1px solid var(--bw-line);
+    color: var(--bw-fg-3);
+    font-size: 11px;
+    font-weight: 750;
+    letter-spacing: 0;
+}
+
+.bw-head-stack {
+    display: grid;
+    gap: 2px;
+    min-width: 0;
+}
+
+.bw-sort {
+    width: fit-content;
+    max-width: 100%;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    overflow: hidden;
+    color: inherit;
+    white-space: nowrap;
+}
+
+.bw-sort-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.bw-sort-subtle {
+    color: var(--bw-fg-3);
+    font-size: 10px;
+    font-weight: 700;
+}
+
+.bw-sort-arrow {
+    width: 20px;
+    height: 20px;
+    flex: 0 0 20px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--bw-line-soft);
+    border-radius: 6px;
+    background: transparent;
+    color: var(--bw-fg-3);
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1;
+    text-decoration: none;
+    transition: background 140ms ease, border-color 140ms ease, color 140ms ease;
+}
+
+.bw-sort-arrow:hover,
+.bw-sort-arrow:focus,
+.bw-sort-arrow.is-active {
+    border-color: color-mix(in srgb, var(--bw-brand) 58%, var(--bw-line));
+    background: color-mix(in srgb, var(--bw-brand) 12%, transparent);
+    color: var(--bw-brand);
+}
+
+.bw-row {
+    min-height: 64px;
+    padding: 10px 18px;
+    border-bottom: 1px solid var(--bw-line-soft);
+    color: var(--bw-fg-1);
+    cursor: pointer;
+    transition: background 140ms ease, border-color 140ms ease, opacity 140ms ease;
+}
+
+.bw-row:hover {
+    background: var(--bw-row-hover);
+}
+
+.bw-row.is-expanded {
+    background: color-mix(in srgb, var(--bw-brand) 8%, var(--bw-row-bg));
+    border-bottom-color: color-mix(in srgb, var(--bw-brand) 34%, var(--bw-line));
+}
+
+.bw-row.is-expanded:hover {
+    background: color-mix(in srgb, var(--bw-brand) 11%, var(--bw-row-bg));
+}
+
+.bw-row.status-caught {
+    background-image: linear-gradient(90deg, color-mix(in srgb, var(--bw-caught) 18%, transparent), transparent 42%);
+    box-shadow: inset 3px 0 0 var(--bw-caught);
+}
+
+.bw-row.status-error {
+    box-shadow: inset 3px 0 0 var(--bw-error);
+}
+
+.bw-row.status-stale {
+    color: var(--bw-fg-2);
+    opacity: 0.68;
+}
+
+.bw-row.status-stale:hover {
+    opacity: 0.84;
+}
+
+.bw-row.status-stale.is-expanded {
+    opacity: 0.92;
+}
+
+.bw-cell-main,
+.bw-cell,
+.bw-source {
+    min-width: 0;
+}
+
+.bw-cell-main {
+    display: grid;
+    grid-template-columns: 32px minmax(0, 1fr);
+    gap: 10px;
+    align-items: center;
+}
+
+.bw-workspace-title {
+    min-width: 0;
+}
+
+.bw-workspace-name,
+[data-fit-name] {
+    display: block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    letter-spacing: 0;
+}
+
+.bw-workspace-name {
+    color: var(--bw-fg-1);
+    font-size: 13px;
+    font-weight: 750;
+    line-height: 18px;
+}
+
+.bw-workspace-name[data-fit="long"],
+[data-fit-name][data-fit="long"] {
+    font-size: 11.5px;
+}
+
+.bw-workspace-name[data-fit="very-long"],
+[data-fit-name][data-fit="very-long"] {
+    font-size: 8px;
+}
+
+.bw-host [data-fit-name][data-fit="very-long"] {
+    font-size: 10px;
+}
+
+.bw-latest {
+    display: block;
+    margin-top: 2px;
+    overflow: hidden;
+    color: var(--bw-fg-2);
+    font-size: 11px;
+    line-height: 16px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.bw-advice-list {
+    margin-top: 4px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.bw-advice-pill {
+    min-height: 20px;
+    padding: 0 7px;
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid color-mix(in srgb, var(--bw-error) 54%, var(--bw-line));
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--bw-error) 12%, transparent);
+    color: var(--bw-fg-1);
+    font-size: 10px;
+    font-weight: 750;
+    line-height: 1;
+    white-space: nowrap;
+}
+
+.bw-cell {
+    overflow: hidden;
+    color: var(--bw-fg-2);
+    font-size: 12px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.bw-host {
+    color: var(--bw-fg-1);
+    font-weight: 700;
+}
+
+.bw-source {
+    display: grid;
+    gap: 2px;
+    font-size: 11px;
+    line-height: 15px;
+}
+
+.bw-source a {
+    overflow: hidden;
+    color: var(--bw-link);
+    font-size: 11.5px;
+    font-weight: 750;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.bw-source-label {
+    color: var(--bw-fg-2);
+    font-size: 11.5px;
+    font-weight: 750;
+}
+
+.bw-source-user {
+    overflow: hidden;
+    color: var(--bw-fg-3);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.bw-status {
+    min-height: 28px;
+    width: fit-content;
+    padding: 0 10px;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    border: 1px solid var(--bw-line);
+    border-radius: 999px;
+    background: var(--bw-panel-3);
+    color: var(--bw-fg-1);
+    font-size: 11px;
+    font-weight: 750;
+    text-transform: capitalize;
+    white-space: nowrap;
+}
+
+.bw-status-dot {
+    width: 7px;
+    height: 7px;
+    flex: 0 0 7px;
+    border-radius: 999px;
+    background: var(--bw-idle);
+}
+
+.bw-status.status-running .bw-status-dot {
+    background: var(--bw-running);
+}
+
+.bw-status.status-stale {
+    border-color: color-mix(in srgb, var(--bw-idle) 62%, var(--bw-line));
+    background: color-mix(in srgb, var(--bw-idle) 14%, transparent);
+    color: var(--bw-fg-2);
+}
+
+.bw-status.status-stale .bw-status-dot {
+    background: var(--bw-idle);
+}
+
+.bw-status.status-caught {
+    border-color: color-mix(in srgb, var(--bw-caught) 62%, var(--bw-line));
+    background: color-mix(in srgb, var(--bw-caught) 18%, transparent);
+}
+
+.bw-status.status-caught .bw-status-dot {
+    background: var(--bw-caught);
+}
+
+.bw-status.status-done .bw-status-dot {
+    background: var(--bw-success);
+}
+
+.bw-status.status-error {
+    border-color: color-mix(in srgb, var(--bw-error) 66%, var(--bw-line));
+    background: color-mix(in srgb, var(--bw-error) 16%, transparent);
+}
+
+.bw-status.status-error .bw-status-dot {
+    background: var(--bw-error);
+}
+
+.bw-actions-cell {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+}
+
+.bw-expand {
+    width: 32px;
+    height: 32px;
+    flex: 0 0 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--bw-line);
+    border-radius: var(--bw-radius);
+    background: var(--bw-row-alt);
+    color: var(--bw-fg-2);
+    font: inherit;
+    font-size: 20px;
+    line-height: 1;
+    cursor: pointer;
+    transition: background 140ms ease, border-color 140ms ease, color 140ms ease;
+}
+
+.bw-expand:hover {
+    background: var(--bw-row-hover);
+    color: var(--bw-fg-1);
+}
+
+.bw-expand[aria-expanded="true"] {
+    border-color: color-mix(in srgb, var(--bw-brand) 58%, var(--bw-line));
+    background: color-mix(in srgb, var(--bw-brand) 14%, var(--bw-row-bg));
+    color: var(--bw-brand);
+}
+
+.bw-expand[aria-expanded="true"] span[aria-hidden="true"] {
+    transform: rotate(90deg);
+}
+
+.bw-expand span[aria-hidden="true"] {
+    transition: transform 160ms ease;
+}
+
+.bw-row-details {
+    padding: 16px 18px 18px;
+    display: grid;
+    gap: 16px;
+    background: var(--bw-row-alt);
+    border-bottom: 1px solid var(--bw-line);
+}
+
+.bw-row-details.is-expanded {
+    background: color-mix(in srgb, var(--bw-brand) 5%, var(--bw-row-alt));
+    border-bottom-color: color-mix(in srgb, var(--bw-brand) 34%, var(--bw-line));
+}
+
+.bw-row-details.status-caught {
+    box-shadow: inset 3px 0 0 var(--bw-caught);
+}
+
+.bw-auth-prompts {
+    display: grid;
+    gap: 8px;
+}
+
+.bw-advice-detail {
+    padding: 12px;
+    display: grid;
+    gap: 8px;
+    border: 1px solid color-mix(in srgb, var(--bw-error) 34%, var(--bw-line));
+    border-radius: var(--bw-radius);
+    background: color-mix(in srgb, var(--bw-error) 8%, var(--bw-row-bg));
+}
+
+.bw-advice-message {
+    display: grid;
+    gap: 3px;
+    color: var(--bw-fg-2);
+    font-size: 12px;
+    line-height: 17px;
+}
+
+.bw-advice-message strong {
+    color: var(--bw-fg-1);
+    font-size: 12px;
+}
+
+.bw-detail-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 12px;
+}
+
+.bw-detail,
+.bw-events,
+.bw-cleanup-actions,
+.bw-edit-actions {
+    min-width: 0;
+    padding-top: 9px;
+    border-top: 1px solid var(--bw-line);
+}
+
+.bw-detail-wide {
+    grid-column: span 2;
+}
+
+.bw-detail-label {
+    display: block;
+    color: var(--bw-fg-3);
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0;
+    line-height: 1;
+}
+
+.bw-detail-value {
+    display: block;
+    margin-top: 6px;
+    overflow: hidden;
+    color: var(--bw-fg-1);
+    font-size: 12px;
+    line-height: 1.45;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.bw-command {
+    white-space: normal;
+    word-break: break-word;
+}
+
+.bw-events {
+    display: grid;
+    gap: 7px;
+}
+
+.bw-events-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: center;
+    color: var(--bw-fg-3);
+    font-size: 10px;
+    font-weight: 800;
+}
+
+.bw-events-more {
+    min-height: 24px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--bw-link);
+    font: inherit;
+    font-size: 11px;
+    font-weight: 750;
+    cursor: pointer;
+}
+
+.bw-events-more:hover {
+    text-decoration: underline;
+}
+
+.bw-event-line {
+    display: grid;
+    grid-template-columns: 70px minmax(0, 1fr);
+    gap: 12px;
+    min-height: 24px;
+    align-items: start;
+    color: var(--bw-fg-2);
+    font-family: var(--bw-mono);
+    font-size: 11.5px;
+    line-height: 1.55;
+}
+
+.bw-event-line > span:first-child {
+    color: var(--bw-fg-3);
+}
+
+.bw-event-line.severity-success {
+    color: var(--bw-success);
+}
+
+.bw-event-line.severity-error {
+    color: var(--bw-error);
+}
+
+.bw-cleanup-actions,
+.bw-edit-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+}
+
+.bw-cleanup-actions > .bw-detail-label,
+.bw-edit-actions > .bw-detail-label {
+    flex: 0 0 100%;
+}
+
+.bw-cleanup-control {
+    display: inline-flex;
+    min-height: 32px;
+    align-items: center;
+}
+
+.bw-badge {
+    min-height: 28px;
+    padding: 0 10px;
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid var(--bw-line);
+    border-radius: 999px;
+    color: var(--bw-fg-1);
+    font-size: 11px;
+    font-weight: 750;
+}
+
+.bw-badge-caught {
+    border-color: color-mix(in srgb, var(--bw-caught) 62%, var(--bw-line));
+    background: color-mix(in srgb, var(--bw-caught) 18%, transparent);
+}
+
+.bw-empty {
+    min-height: 112px;
+    padding: 24px 18px;
+    display: grid;
+    align-content: center;
+    gap: 4px;
+    color: var(--bw-fg-2);
+    border-bottom: 1px solid var(--bw-line-soft);
+}
+
+.bw-empty strong {
+    color: var(--bw-fg-1);
+    font-size: 14px;
+}
+
+.bw-toolbar {
+    min-height: 46px;
+    padding: 0 18px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    background: var(--bw-top);
+    border-top: 1px solid var(--bw-line);
+    color: var(--bw-fg-2);
+    font-size: 11.5px;
+}
+
+.bw-admin {
+    max-width: 1040px;
+}
+
+.bw-admin-panel {
+    min-height: 0;
+}
+
+.bw-admin-header {
+    min-height: 78px;
+    padding: 16px 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    background: var(--bw-panel);
+    border-bottom: 1px solid var(--bw-line);
+}
+
+.bw-admin-title {
+    margin: 6px 0 0;
+    color: var(--bw-fg-1);
+    font-size: 20px;
+    font-weight: 750;
+    line-height: 1.2;
+}
+
+.bw-admin-table-wrap {
+    overflow-x: auto;
+    background: var(--bw-row-bg);
+}
+
+.bw-admin-table {
+    width: 100%;
+    min-width: 720px;
+    border-collapse: collapse;
+}
+
+.bw-admin-table th,
+.bw-admin-table td {
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--bw-line-soft);
+    color: var(--bw-fg-2);
+    font-size: 12px;
+    vertical-align: middle;
+}
+
+.bw-admin-table thead th {
+    background: var(--bw-row-alt);
+    color: var(--bw-fg-3);
+    font-size: 11px;
+    font-weight: 800;
+    letter-spacing: 0;
+}
+
+.bw-admin-table tbody th {
+    color: var(--bw-fg-1);
+    font-weight: 750;
+}
+
+.bw-admin-table tbody tr:hover {
+    background: var(--bw-row-hover);
+}
+
+.bw-admin-user {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+}
+
+.bw-admin-owner-badge {
+    min-height: 24px;
+    padding: 0 8px;
+    border: 1px solid var(--bw-line);
+    border-radius: 999px;
+    background: var(--bw-panel-3);
+    color: var(--bw-fg-2);
+    font: inherit;
+    font-size: 10.5px;
+    font-weight: 800;
+}
+
+.bw-admin .btn-group {
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.bw-admin .btn-group > .btn,
+.bw-admin .btn {
+    border-radius: var(--bw-radius) !important;
+    font-size: 11px;
+    font-weight: 700;
+}
+
+@media (max-width: 1080px) {
+    .bw-head,
+    .bw-row {
+        grid-template-columns:
+            minmax(260px, 2fr)
+            minmax(150px, 0.9fr)
+            minmax(136px, 0.75fr)
+            minmax(132px, auto);
+    }
+
+    .bw-head span:nth-child(2),
+    .bw-row > :nth-child(2),
+    .bw-head span:nth-child(4),
+    .bw-row > :nth-child(4) {
+        display: none;
+    }
+
+    .bw-detail-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 760px) {
+    .bw-topbar {
+        grid-template-columns: 1fr;
+        justify-items: start;
+        padding: 12px 16px;
+    }
+
+    .bw-nav {
+        width: 100%;
+        justify-content: flex-start;
+        flex-wrap: wrap;
+    }
+
+    .bw-app {
+        margin: 12px auto 24px;
+        padding: 0 10px;
+    }
+
+    .bw-filterbar,
+    .bw-search-form {
+        grid-template-columns: 1fr;
+    }
+
+    .bw-head {
+        display: none;
+    }
+
+    .bw-row {
+        grid-template-columns: 1fr;
+        gap: 8px;
+        align-items: start;
+    }
+
+    .bw-actions-cell {
+        justify-content: flex-start;
+    }
+
+    .bw-detail-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .bw-detail-wide {
+        grid-column: auto;
+    }
+
+    .bw-toolbar {
+        min-height: 58px;
+        align-items: flex-start;
+        justify-content: center;
+        flex-direction: column;
+        padding: 10px 18px;
+    }
 }

--- a/src/boardwalkd/static/boardwalkd.css
+++ b/src/boardwalkd/static/boardwalkd.css
@@ -503,7 +503,7 @@ a {
     box-shadow: inset 3px 0 0 var(--bw-running);
 }
 
-.bw-lane-attention .bw-lane-header {
+.bw-lane-caught .bw-lane-header {
     box-shadow: inset 3px 0 0 var(--bw-caught);
 }
 

--- a/src/boardwalkd/static/boardwalkd.js
+++ b/src/boardwalkd/static/boardwalkd.js
@@ -5,9 +5,9 @@
 
     function storedTheme() {
         try {
-            return localStorage.getItem("boardwalk.theme") || "light";
+            return localStorage.getItem("boardwalk.theme") || "dark";
         } catch (error) {
-            return "light";
+            return "dark";
         }
     }
 

--- a/src/boardwalkd/static/boardwalkd.js
+++ b/src/boardwalkd/static/boardwalkd.js
@@ -1,0 +1,298 @@
+(function () {
+    var EXPANDED_WORKSPACE_KEY = "boardwalk.expandedWorkspace";
+    var EXPANDED_EVENTS_KEY = "boardwalk.expandedEvents";
+    var activeControlSnapshot = null;
+
+    function storedTheme() {
+        try {
+            return localStorage.getItem("boardwalk.theme") || "light";
+        } catch (error) {
+            return "light";
+        }
+    }
+
+    function rememberTheme(theme) {
+        try {
+            localStorage.setItem("boardwalk.theme", theme);
+        } catch (error) {
+            return;
+        }
+    }
+
+    function storedSessionValue(key) {
+        try {
+            return sessionStorage.getItem(key) || "";
+        } catch (error) {
+            return "";
+        }
+    }
+
+    function rememberSessionValue(key, value) {
+        try {
+            if (value) {
+                sessionStorage.setItem(key, value);
+            } else {
+                sessionStorage.removeItem(key);
+            }
+        } catch (error) {
+            return;
+        }
+    }
+
+    function storedEventKeys() {
+        var raw = storedSessionValue(EXPANDED_EVENTS_KEY);
+        return raw ? raw.split(",").filter(Boolean) : [];
+    }
+
+    function rememberEventKey(key) {
+        if (!key) return;
+        var keys = storedEventKeys();
+        if (keys.indexOf(key) === -1) {
+            keys.push(key);
+            rememberSessionValue(EXPANDED_EVENTS_KEY, keys.join(","));
+        }
+    }
+
+    function findByWorkspaceKey(root, selector, key) {
+        var match = null;
+        (root || document).querySelectorAll(selector).forEach(function (element) {
+            if (!match && element.dataset.workspaceKey === key) {
+                match = element;
+            }
+        });
+        return match;
+    }
+
+    function applyTheme(theme) {
+        var root = document.documentElement;
+        var dark = theme === "dark";
+        root.classList.toggle("bw-theme-dark", dark);
+        root.classList.toggle("bw-theme-light", !dark);
+        rememberTheme(dark ? "dark" : "light");
+
+        var toggle = document.querySelector("[data-theme-toggle]");
+        if (toggle) {
+            toggle.setAttribute("aria-pressed", dark ? "true" : "false");
+            toggle.setAttribute("aria-label", dark ? "Switch to light mode" : "Switch to dark mode");
+            toggle.setAttribute("title", dark ? "Switch to light mode" : "Switch to dark mode");
+        }
+    }
+
+    function fitNames(root) {
+        (root || document).querySelectorAll("[data-fit-name]").forEach(function (el) {
+            el.dataset.fit = "normal";
+            if (el.scrollWidth <= el.clientWidth + 0.5) return;
+            el.dataset.fit = "long";
+            if (el.scrollWidth <= el.clientWidth + 0.5) return;
+            el.dataset.fit = "very-long";
+        });
+    }
+
+    function closeRows(remember) {
+        document.querySelectorAll(".bw-row-details").forEach(function (panel) {
+            panel.hidden = true;
+            panel.classList.remove("is-expanded");
+        });
+        document.querySelectorAll("[data-workspace-row]").forEach(function (row) {
+            row.classList.remove("is-expanded");
+        });
+        document.querySelectorAll("[data-row-toggle]").forEach(function (toggle) {
+            toggle.setAttribute("aria-expanded", "false");
+        });
+        if (remember) {
+            rememberSessionValue(EXPANDED_WORKSPACE_KEY, "");
+        }
+    }
+
+    function openRowByKey(key, remember) {
+        var button = findByWorkspaceKey(document, "[data-row-toggle]", key);
+        if (!button) return false;
+        var panel = document.getElementById(button.getAttribute("aria-controls"));
+        var row = findByWorkspaceKey(document, "[data-workspace-row]", key);
+        if (!panel) return false;
+
+        closeRows(false);
+        panel.hidden = false;
+        panel.classList.add("is-expanded");
+        if (row) {
+            row.classList.add("is-expanded");
+        }
+        button.setAttribute("aria-expanded", "true");
+        if (remember) {
+            rememberSessionValue(EXPANDED_WORKSPACE_KEY, key);
+        }
+        fitNames(panel);
+        return true;
+    }
+
+    function restoreExpandedState(root) {
+        var key = storedSessionValue(EXPANDED_WORKSPACE_KEY);
+        if (key) {
+            openRowByKey(key, false);
+        }
+        storedEventKeys().forEach(function (eventKey) {
+            var panel = findByWorkspaceKey(root || document, ".bw-row-details", eventKey);
+            if (!panel) return;
+            panel.querySelectorAll("[data-event-extra]").forEach(function (line) {
+                line.hidden = false;
+            });
+            panel.querySelectorAll("[data-events-toggle]").forEach(function (button) {
+                button.hidden = true;
+            });
+        });
+    }
+
+    function bindRows(root) {
+        (root || document).querySelectorAll("[data-row-toggle]").forEach(function (button) {
+            if (button.dataset.bound === "1") return;
+            button.dataset.bound = "1";
+            button.addEventListener("click", function (event) {
+                event.stopPropagation();
+                var target = document.getElementById(button.getAttribute("aria-controls"));
+                if (!target) return;
+                var open = target.hidden;
+                if (open) {
+                    openRowByKey(button.dataset.workspaceKey, true);
+                } else {
+                    closeRows(true);
+                }
+            });
+        });
+
+        (root || document).querySelectorAll("[data-workspace-row]").forEach(function (row) {
+            if (row.dataset.bound === "1") return;
+            row.dataset.bound = "1";
+            row.addEventListener("click", function (event) {
+                if (event.target.closest("a, button, input, select, label")) return;
+                var toggle = row.querySelector("[data-row-toggle]");
+                if (toggle) toggle.click();
+            });
+        });
+    }
+
+    function bindEventToggles(root) {
+        (root || document).querySelectorAll("[data-events-toggle]").forEach(function (button) {
+            if (button.dataset.bound === "1") return;
+            button.dataset.bound = "1";
+            button.addEventListener("click", function (event) {
+                event.stopPropagation();
+                var container = button.closest(".bw-events");
+                if (!container) return;
+                container.querySelectorAll("[data-event-extra]").forEach(function (line) {
+                    line.hidden = false;
+                });
+                button.hidden = true;
+                var panel = button.closest(".bw-row-details");
+                if (panel) {
+                    rememberEventKey(panel.dataset.workspaceKey);
+                }
+            });
+        });
+    }
+
+    function bindThemeToggle() {
+        var toggle = document.querySelector("[data-theme-toggle]");
+        if (!toggle || toggle.dataset.bound === "1") return;
+        toggle.dataset.bound = "1";
+        toggle.addEventListener("click", function () {
+            applyTheme(document.documentElement.classList.contains("bw-theme-dark") ? "light" : "dark");
+        });
+    }
+
+    function isEditableControl(element) {
+        if (!element || !element.matches) return false;
+        if (!element.matches("input, textarea, select")) return false;
+        return element.type !== "hidden";
+    }
+
+    function userIsEditingDashboard() {
+        var active = document.activeElement;
+        return isEditableControl(active) && Boolean(active.closest(".bw-dashboard"));
+    }
+
+    function fieldMatchesSnapshot(element, snapshot) {
+        if (!element || !snapshot) return false;
+        if (element.name !== snapshot.name) return false;
+        if (element.tagName !== snapshot.tagName) return false;
+        return !snapshot.type || element.type === snapshot.type;
+    }
+
+    function findControlBySnapshot(root, snapshot) {
+        var match = null;
+        (root || document).querySelectorAll("input, textarea, select").forEach(function (element) {
+            if (!match && fieldMatchesSnapshot(element, snapshot)) {
+                match = element;
+            }
+        });
+        return match;
+    }
+
+    function captureActiveControl() {
+        var active = document.activeElement;
+        if (!isEditableControl(active) || !active.closest(".bw-dashboard")) return null;
+        return {
+            name: active.name || "",
+            tagName: active.tagName,
+            type: active.type || "",
+            value: active.value,
+            selectionStart: typeof active.selectionStart === "number" ? active.selectionStart : null,
+            selectionEnd: typeof active.selectionEnd === "number" ? active.selectionEnd : null,
+        };
+    }
+
+    function restoreActiveControl(root) {
+        if (!activeControlSnapshot || !activeControlSnapshot.name) return;
+        var control = findControlBySnapshot(root || document, activeControlSnapshot);
+        if (!control) {
+            activeControlSnapshot = null;
+            return;
+        }
+        control.value = activeControlSnapshot.value;
+        control.focus({ preventScroll: true });
+        if (
+            typeof control.setSelectionRange === "function" &&
+            activeControlSnapshot.selectionStart !== null &&
+            activeControlSnapshot.selectionEnd !== null
+        ) {
+            control.setSelectionRange(activeControlSnapshot.selectionStart, activeControlSnapshot.selectionEnd);
+        }
+        activeControlSnapshot = null;
+    }
+
+    function isDashboardAutoRefresh(event) {
+        var detail = event.detail || {};
+        var element = detail.elt;
+        return Boolean(element && element.matches && element.matches(".bw-dashboard"));
+    }
+
+    function boot(root) {
+        bindThemeToggle();
+        bindRows(root || document);
+        bindEventToggles(root || document);
+        restoreExpandedState(root || document);
+        fitNames(root || document);
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        applyTheme(storedTheme());
+        boot(document);
+    });
+
+    if (document.body) {
+        document.body.addEventListener("htmx:beforeRequest", function (event) {
+            if (isDashboardAutoRefresh(event) && userIsEditingDashboard()) {
+                event.preventDefault();
+            }
+        });
+        document.body.addEventListener("htmx:beforeSwap", function () {
+            activeControlSnapshot = captureActiveControl();
+        });
+        document.body.addEventListener("htmx:afterSwap", function (event) {
+            boot(event.target);
+        });
+        document.body.addEventListener("htmx:afterSettle", function (event) {
+            restoreExpandedState(event.target);
+            restoreActiveControl(event.target);
+        });
+    }
+})();

--- a/src/boardwalkd/static/boardwalkd.js
+++ b/src/boardwalkd/static/boardwalkd.js
@@ -125,6 +125,8 @@
         return true;
     }
 
+    // Expansion state is per browser tab via sessionStorage. HTMX refreshes can
+    // redraw the table without turning one user's expanded row into server state.
     function restoreExpandedState(root) {
         var key = storedSessionValue(EXPANDED_WORKSPACE_KEY);
         if (key) {
@@ -227,6 +229,8 @@
         return match;
     }
 
+    // Auto-refresh replaces the dashboard fragment. Capture the focused control
+    // so in-progress search/filter typing survives the swap.
     function captureActiveControl() {
         var active = document.activeElement;
         if (!isEditableControl(active) || !active.closest(".bw-dashboard")) return null;

--- a/src/boardwalkd/static/favicon.svg
+++ b/src/boardwalkd/static/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="Boardwalk">
+  <rect width="64" height="64" rx="14" fill="#1d2636"/>
+  <path d="M30 27c4 7 5 19 1 30h-6c4-10 4-21 1-29z" fill="#d99f5f"/>
+  <path d="M30 28c-10-1-17-5-21-11 9-1 17 2 22 8z" fill="#7cc7a2"/>
+  <path d="M31 27c-9-6-12-13-12-19 8 4 13 10 14 17z" fill="#5cae91"/>
+  <path d="M33 26c-1-9 3-16 10-20 1 10-3 17-8 21z" fill="#7cc7a2"/>
+  <path d="M34 27c9-6 18-6 25-2-9 6-17 6-24 4z" fill="#5cae91"/>
+  <path d="M32 29c10 1 17 6 20 13-10 0-17-5-21-11z" fill="#7cc7a2"/>
+  <path d="M17 58h29c-3 3-24 3-29 0z" fill="#e7c987"/>
+</svg>

--- a/src/boardwalkd/templates/admin.html
+++ b/src/boardwalkd/templates/admin.html
@@ -1,15 +1,17 @@
 {% extends "base.html" %}
 
 {% block main %}
-<div class="container-xxl">
-    <div class="row pb-2">
-        <div class="container bg-light border border-dark rounded">
-            <div class="row pt-2 pb-2 border-bottom border-dark">
-                <div class="col-12">
-                    <span class="h3" id="users">Users</span>
-                </div>
+<section class="bw-app bw-admin">
+    <div class="bw-frame bw-admin-panel">
+        <header class="bw-admin-header">
+            <div>
+                <span class="bw-detail-label">Admin</span>
+                <h1 class="bw-admin-title" id="users">Users and roles</h1>
             </div>
-            <table class="table">
+            <a href="/" class="bw-button bw-button-secondary">Dashboard</a>
+        </header>
+        <div class="bw-admin-table-wrap">
+            <table class="bw-admin-table">
                 <thead>
                     <tr>
                         <th scope="col">Email</th>
@@ -20,10 +22,15 @@
                 <tbody>
                     {% for user in users.values() %}
                     <tr>
-                        <th scope="row">{{ user.email }}{% if user.email == owner %} <button type="button"
-                                class="btn btn-sm btn-outline-secondary"
+                        <th scope="row">
+                            <span class="bw-admin-user">
+                                <span>{{ user.email }}</span>
+                                {% if user.email == owner %}
+                                <button type="button" class="bw-admin-owner-badge"
                                 title="The owner is defined by the server configuration. They will be marked as Enabled and maintain the Admin role every time the server starts"
-                                disabled>Owner</button>{% end %}
+                                disabled>Owner</button>
+                                {% end %}
+                            </span>
                         </th>
                         <td>{% include "admin_user_roles.html" %}</td>
                         <td>{% include "admin_user_enable.html" %}</td>
@@ -33,5 +40,5 @@
             </table>
         </div>
     </div>
-</div>
+</section>
 {% end %}

--- a/src/boardwalkd/templates/base.html
+++ b/src/boardwalkd/templates/base.html
@@ -3,7 +3,7 @@
 {% set theme_logo_url = handler.settings.get("theme_logo_url", "") %}
 {% set theme_logo_alt = handler.settings.get("theme_logo_alt", "") %}
 {% set theme_brand_name = handler.settings.get("theme_brand_name", "Boardwalk") or "Boardwalk" %}
-<html lang="en" class="bw-theme-light">
+<html lang="en" class="bw-theme-dark">
 
 <head>
     <meta charset="utf-8">
@@ -44,7 +44,7 @@
         <nav class="bw-nav" aria-label="Primary">
             <a href="/" class="bw-nav-link">Dashboard</a>
             <a href="/admin" class="bw-nav-link">Admin</a>
-            <button type="button" class="bw-theme-toggle" data-theme-toggle aria-label="Switch to dark mode" aria-pressed="false" title="Switch to dark mode">
+            <button type="button" class="bw-theme-toggle" data-theme-toggle aria-label="Switch to light mode" aria-pressed="true" title="Switch to light mode">
                 <span class="bw-theme-toggle-icon bw-theme-toggle-icon-light" aria-hidden="true">&#9788;</span>
                 <span class="bw-theme-toggle-icon bw-theme-toggle-icon-dark" aria-hidden="true">&#9790;</span>
                 <span class="bw-theme-toggle-thumb"></span>

--- a/src/boardwalkd/templates/base.html
+++ b/src/boardwalkd/templates/base.html
@@ -1,21 +1,26 @@
 <!doctype html>
-<html lang="en">
+{% set theme_css_url = handler.settings.get("theme_css_url", "") %}
+{% set theme_logo_url = handler.settings.get("theme_logo_url", "") %}
+{% set theme_logo_alt = handler.settings.get("theme_logo_alt", "") %}
+{% set theme_brand_name = handler.settings.get("theme_brand_name", "Boardwalk") or "Boardwalk" %}
+<html lang="en" class="bw-theme-light">
 
 <head>
-    <!-- Required meta tags -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <!-- Bootstrap CSS -->
+    <link rel="icon" href="{{ static_url('favicon.svg') }}" type="image/svg+xml">
     <link href="{{ static_url('bootstrap.min.css') }}" rel="stylesheet">
-    <!-- BoardwalkD CSS -->
     <link href="{{ static_url('boardwalkd.css') }}" rel="stylesheet">
+    {% if theme_css_url %}
+    <link href="{{ theme_css_url # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}" rel="stylesheet">
+    {% end %}
 
-    <title>Boardwalk · {{ title }}</title>
+    <title>{{ theme_brand_name }} · {{ title }}</title>
 
     {% block head %}{% end %}
-
 </head>
+
 {# The line below causes the _xsrf cookie to always be set #}
 <!-- {% module xsrf_form_html() %} -->
 <script>
@@ -26,38 +31,35 @@
 </script>
 
 <body hx-headers='js:{"X-XSRFToken": getCookie("_xsrf")}'>
-    <nav class="navbar">
-        <div class="container-xxl border-bottom">
-            <a href="/" class="navbar-brand text-dark text-left">
-                Boardwalk
-                <font size="1" class="text-muted">{{ server_version() }}</font>
-            </a>
-            <a href="/admin" class="text-secondary text-right">
-                Admin
-            </a>
-        </div>
-    </nav>
+    <header class="bw-topbar">
+        <a href="/" class="bw-brand" aria-label="{{ theme_brand_name }}">
+            {% if theme_logo_url %}
+            <img src="{{ theme_logo_url # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}" alt="{{ theme_logo_alt or theme_brand_name }}" class="bw-brand-mark">
+            {% else %}
+            <span class="bw-brand-mark bw-brand-mark-text">B</span>
+            {% end %}
+            <span>{{ theme_brand_name }}</span>
+            <span class="bw-version">{{ server_version() }}</span>
+        </a>
+        <nav class="bw-nav" aria-label="Primary">
+            <a href="/" class="bw-nav-link">Dashboard</a>
+            <a href="/admin" class="bw-nav-link">Admin</a>
+            <button type="button" class="bw-theme-toggle" data-theme-toggle aria-label="Switch to dark mode" aria-pressed="false" title="Switch to dark mode">
+                <span class="bw-theme-toggle-icon bw-theme-toggle-icon-light" aria-hidden="true">&#9788;</span>
+                <span class="bw-theme-toggle-icon bw-theme-toggle-icon-dark" aria-hidden="true">&#9790;</span>
+                <span class="bw-theme-toggle-thumb"></span>
+            </button>
+        </nav>
+    </header>
 
     <main>
         {% block main %}{% end %}
     </main>
 
-    <!-- Bootstrap JS -->
     <script src="{{ static_url('bootstrap.bundle.min.js') }}" defer></script>
-    <!-- htmx JS -->
     <script src="{{ static_url('htmx.min.js') }}" defer></script>
+    <script src="{{ static_url('boardwalkd.js') }}" defer></script>
     {% block bottom %}{% end %}
-
-    <!-- GitHub Corner; MIT Licensed; attribution: https://github.com/tholman/github-corners -->
-    <a href="https://github.com/Backblaze/boardwalk/" class="github-corner" aria-label="View source on GitHub">
-        <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#e20626; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
-            <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
-            <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
-            <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-        </svg>
-    </a>
-    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
-
 </body>
 
 </html>

--- a/src/boardwalkd/templates/index.html
+++ b/src/boardwalkd/templates/index.html
@@ -1,13 +1,8 @@
 {% extends "base.html" %}
 
 {% block main %}
-<section id="workspaces">
-    {% if edit %}
-    <div class="container-lg" hx-get="/workspaces?edit=1" hx-trigger="load, every 8s" hx-swap="innerHTML">
+<section class="bw-app" id="workspaces">
+    <div class="bw-frame" hx-get="{{ workspaces_url }}" hx-trigger="load" hx-swap="innerHTML">
     </div>
-    {% else %}
-    <div class="container-lg" hx-get="/workspaces" hx-trigger="load, every 8s" hx-swap="innerHTML">
-    </div>
-    {% end %}
 </section>
 {% end %}

--- a/src/boardwalkd/templates/index_workspace.html
+++ b/src/boardwalkd/templates/index_workspace.html
@@ -4,7 +4,7 @@
     <nav class="bw-tabs" aria-label="Workspace groups">
         {% for group in dashboard.groups %}
         <a class="bw-tab{% if group.active %} is-active{% end %}"
-            href="{{ canonical_url(filters, edit=edit, group=group.label) }}"
+            href="{{ canonical_url(filters, edit=edit, group=group.label) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
             hx-get="{{ partial_url(filters, edit=edit, push_url=True, group=group.label) }}"
             hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false">
             <span>{{ group.label }}</span>
@@ -82,11 +82,11 @@
 
         <div class="bw-filter-actions">
             {% if edit %}
-            <a class="bw-button bw-button-secondary" href="{{ canonical_url(filters) }}"
+            <a class="bw-button bw-button-secondary" href="{{ canonical_url(filters) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
                 hx-get="{{ partial_url(filters, push_url=True) }}" hx-target="closest .bw-frame"
                 hx-swap="innerHTML" hx-push-url="false">Exit edit</a>
             {% else %}
-            <a class="bw-button bw-button-secondary" href="{{ canonical_url(filters, edit=True) }}"
+            <a class="bw-button bw-button-secondary" href="{{ canonical_url(filters, edit=True) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
                 hx-get="{{ partial_url(filters, edit=True, push_url=True) }}" hx-target="closest .bw-frame"
                 hx-swap="innerHTML" hx-push-url="false">Edit</a>
             {% end %}
@@ -132,54 +132,54 @@
                     <span class="bw-head-stack">
                         <span class="bw-sort">
                             <span class="bw-sort-label">Workspace</span>
-                            <a class="bw-sort-arrow{% if filters.sort == "workspace" %} is-active{% end %}"
-                                href="{{ sort_url("/", filters, "workspace", edit=edit) }}"
-                                hx-get="{{ sort_url("/workspaces", filters, "workspace", edit=edit, push_url="1") }}"
+                            <a class="bw-sort-arrow{% if filters.sort == 'workspace' %} is-active{% end %}"
+                                href="{{ sort_url('/', filters, 'workspace', edit=edit) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
+                                hx-get="{{ sort_url('/workspaces', filters, 'workspace', edit=edit, push_url='1') }}"
                                 hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
-                                aria-label="{% if filters.sort == "workspace" %}Workspace sorted {{ filters.direction }}; switch sort direction{% else %}Workspace sorted by default; sort by workspace{% end %}">
-                                <span aria-hidden="true">{% if filters.sort == "workspace" %}{% if filters.direction == "asc" %}&uarr;{% else %}&darr;{% end %}{% else %}&#8597;{% end %}</span>
+                                aria-label="{% if filters.sort == 'workspace' %}Workspace sorted {{ filters.direction }}; switch sort direction{% else %}Workspace sorted by default; sort by workspace{% end %}">
+                                <span aria-hidden="true">{% if filters.sort == 'workspace' %}{% if filters.direction == 'asc' %}&uarr;{% else %}&darr;{% end %}{% else %}&#8597;{% end %}</span>
                             </a>
                         </span>
                         <span class="bw-sort bw-sort-subtle">
                             <span class="bw-sort-label">Latest</span>
-                            <a class="bw-sort-arrow{% if filters.sort == "updated" %} is-active{% end %}"
-                                href="{{ sort_url("/", filters, "updated", edit=edit) }}"
-                                hx-get="{{ sort_url("/workspaces", filters, "updated", edit=edit, push_url="1") }}"
+                            <a class="bw-sort-arrow{% if filters.sort == 'updated' %} is-active{% end %}"
+                                href="{{ sort_url('/', filters, 'updated', edit=edit) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
+                                hx-get="{{ sort_url('/workspaces', filters, 'updated', edit=edit, push_url='1') }}"
                                 hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
-                                aria-label="{% if filters.sort == "updated" %}Latest event sorted {{ filters.direction }}; switch sort direction{% else %}Latest event sorted by default; sort by latest event{% end %}">
-                                <span aria-hidden="true">{% if filters.sort == "updated" %}{% if filters.direction == "asc" %}&uarr;{% else %}&darr;{% end %}{% else %}&#8597;{% end %}</span>
+                                aria-label="{% if filters.sort == 'updated' %}Latest event sorted {{ filters.direction }}; switch sort direction{% else %}Latest event sorted by default; sort by latest event{% end %}">
+                                <span aria-hidden="true">{% if filters.sort == 'updated' %}{% if filters.direction == 'asc' %}&uarr;{% else %}&darr;{% end %}{% else %}&#8597;{% end %}</span>
                             </a>
                         </span>
                     </span>
                     <span>Limit</span>
                     <span class="bw-sort">
                         <span class="bw-sort-label">Current host</span>
-                        <a class="bw-sort-arrow{% if filters.sort == "current_host" %} is-active{% end %}"
-                            href="{{ sort_url("/", filters, "current_host", edit=edit) }}"
-                            hx-get="{{ sort_url("/workspaces", filters, "current_host", edit=edit, push_url="1") }}"
+                        <a class="bw-sort-arrow{% if filters.sort == 'current_host' %} is-active{% end %}"
+                            href="{{ sort_url('/', filters, 'current_host', edit=edit) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
+                            hx-get="{{ sort_url('/workspaces', filters, 'current_host', edit=edit, push_url='1') }}"
                             hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
-                            aria-label="{% if filters.sort == "current_host" %}Current host sorted {{ filters.direction }}; switch sort direction{% else %}Current host sorted by default; sort by current host{% end %}">
-                            <span aria-hidden="true">{% if filters.sort == "current_host" %}{% if filters.direction == "asc" %}&uarr;{% else %}&darr;{% end %}{% else %}&#8597;{% end %}</span>
+                            aria-label="{% if filters.sort == 'current_host' %}Current host sorted {{ filters.direction }}; switch sort direction{% else %}Current host sorted by default; sort by current host{% end %}">
+                            <span aria-hidden="true">{% if filters.sort == 'current_host' %}{% if filters.direction == 'asc' %}&uarr;{% else %}&darr;{% end %}{% else %}&#8597;{% end %}</span>
                         </a>
                     </span>
                     <span class="bw-sort">
                         <span class="bw-sort-label">Source</span>
-                        <a class="bw-sort-arrow{% if filters.sort == "source" %} is-active{% end %}"
-                            href="{{ sort_url("/", filters, "source", edit=edit) }}"
-                            hx-get="{{ sort_url("/workspaces", filters, "source", edit=edit, push_url="1") }}"
+                        <a class="bw-sort-arrow{% if filters.sort == 'source' %} is-active{% end %}"
+                            href="{{ sort_url('/', filters, 'source', edit=edit) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
+                            hx-get="{{ sort_url('/workspaces', filters, 'source', edit=edit, push_url='1') }}"
                             hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
-                            aria-label="{% if filters.sort == "source" %}Source sorted {{ filters.direction }}; switch sort direction{% else %}Source sorted by default; sort by source{% end %}">
-                            <span aria-hidden="true">{% if filters.sort == "source" %}{% if filters.direction == "asc" %}&uarr;{% else %}&darr;{% end %}{% else %}&#8597;{% end %}</span>
+                            aria-label="{% if filters.sort == 'source' %}Source sorted {{ filters.direction }}; switch sort direction{% else %}Source sorted by default; sort by source{% end %}">
+                            <span aria-hidden="true">{% if filters.sort == 'source' %}{% if filters.direction == 'asc' %}&uarr;{% else %}&darr;{% end %}{% else %}&#8597;{% end %}</span>
                         </a>
                     </span>
                     <span class="bw-sort">
                         <span class="bw-sort-label">Status</span>
-                        <a class="bw-sort-arrow{% if filters.sort == "status" %} is-active{% end %}"
-                            href="{{ sort_url("/", filters, "status", edit=edit) }}"
-                            hx-get="{{ sort_url("/workspaces", filters, "status", edit=edit, push_url="1") }}"
+                        <a class="bw-sort-arrow{% if filters.sort == 'status' %} is-active{% end %}"
+                            href="{{ sort_url('/', filters, 'status', edit=edit) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
+                            hx-get="{{ sort_url('/workspaces', filters, 'status', edit=edit, push_url='1') }}"
                             hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
-                            aria-label="{% if filters.sort == "status" %}Status sorted {{ filters.direction }}; switch sort direction{% else %}Status sorted by default; sort by status{% end %}">
-                            <span aria-hidden="true">{% if filters.sort == "status" %}{% if filters.direction == "asc" %}&uarr;{% else %}&darr;{% end %}{% else %}&#8597;{% end %}</span>
+                            aria-label="{% if filters.sort == 'status' %}Status sorted {{ filters.direction }}; switch sort direction{% else %}Status sorted by default; sort by status{% end %}">
+                            <span aria-hidden="true">{% if filters.sort == 'status' %}{% if filters.direction == 'asc' %}&uarr;{% else %}&darr;{% end %}{% else %}&#8597;{% end %}</span>
                         </a>
                     </span>
                     <span>Actions</span>

--- a/src/boardwalkd/templates/index_workspace.html
+++ b/src/boardwalkd/templates/index_workspace.html
@@ -1,102 +1,248 @@
-<div class="div row">
-    <div class="col">
-        <h2>Workspaces</h2>
-    </div>
-    <div class="col text-end">
-        {% if edit %}
-        <a href="/" class="btn btn-sm btn-light border-danger" aria-current="Exit workspace edit mode"
-            title="Exit workspace edit mode">Edit</a>
-        {% else %}
-        <a href="/?edit=1" class="btn btn-sm btn-light" aria-current="Enter workspace edit mode"
-            title="Enter workspace edit mode">Edit</a>
+{% set filters = dashboard.filters %}
+<div class="bw-dashboard" hx-get="{{ partial_url(filters, edit=edit) }}" hx-trigger="every 8s"
+    hx-target="closest .bw-frame" hx-swap="innerHTML">
+    <nav class="bw-tabs" aria-label="Workspace groups">
+        {% for group in dashboard.groups %}
+        <a class="bw-tab{% if group.active %} is-active{% end %}"
+            href="{{ canonical_url(filters, edit=edit, group=group.label) }}"
+            hx-get="{{ partial_url(filters, edit=edit, push_url=True, group=group.label) }}"
+            hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false">
+            <span>{{ group.label }}</span>
+            <span class="bw-tab-count">{{ group.count }}</span>
+        </a>
         {% end %}
-    </div>
-</div>
-{% if orphan_auth_prompts %}
-<div class="row pb-2">
-    <div class="container bg-warning-subtle border border-warning rounded">
-        <div class="row pt-2 pb-2">
-            <div class="col">
-                <h3 class="h5">Active authentication prompts</h3>
-                <table class="table table-sm mb-0">
-                    <tbody>
-                        {% for prompt in orphan_auth_prompts %}
-                        <tr title="{{ prompt.created_time }}">
-                            <td>
-                                {% if prompt.workspace %}
-                                {{ prompt.workspace }}
-                                {% else %}
-                                &lt;unknown workspace&gt;
-                                {% end %}
-                            </td>
-                            <td>
-                                {% if prompt.auth_context.get('worker_command') %}
-                                {{ prompt.auth_context.get('worker_command') }}
-                                {% else %}
-                                &lt;unknown command&gt;
-                                {% end %}
-                            </td>
-                            <td>
-                                {% if prompt.auth_context.get('worker_limit') %}
-                                {{ prompt.auth_context.get('worker_limit') }}
-                                {% else %}
-                                &lt;unknown limit&gt;
-                                {% end %}
-                            </td>
-                            <td>
-                                {% if prompt.auth_context.get('deployment_url') %}
-                                <a href="{{ prompt.auth_context.get('deployment_url') # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}">Deployment</a>
-                                {% else %}
-                                Deployment unavailable
-                                {% end %}
-                            </td>
-                            <td class="text-end">
-                                <a href="{{ prompt.login_url # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}" class="btn btn-sm btn-warning">Open login</a>
-                            </td>
-                        </tr>
-                        {% end %}
-                    </tbody>
-                </table>
-            </div>
+    </nav>
+
+    <div class="bw-filterbar">
+        <form class="bw-search-form" action="/" method="get" hx-get="/workspaces"
+            hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
+            hx-vals='{"push_url":"1"}'>
+            <input type="hidden" name="group" value="{{ filters.group }}">
+            <input type="hidden" name="status" value="{{ filters.status }}">
+            <input type="hidden" name="source" value="{{ filters.source }}">
+            <input type="hidden" name="sort" value="{{ filters.sort }}">
+            <input type="hidden" name="direction" value="{{ filters.direction }}">
+            {% if edit %}
+            <input type="hidden" name="edit" value="1">
+            {% end %}
+            <label class="bw-field bw-field-search">
+                <span>Search</span>
+                <input class="bw-input" type="search" name="search" value="{{ filters.search }}"
+                    placeholder="Workspace, host, limit, user, build">
+            </label>
+            <button type="submit" class="bw-button bw-button-primary">Search</button>
+        </form>
+
+        <form class="bw-select-form" action="/" method="get" hx-get="/workspaces"
+            hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
+            hx-vals='{"push_url":"1"}'>
+            <input type="hidden" name="group" value="{{ filters.group }}">
+            <input type="hidden" name="search" value="{{ filters.search }}">
+            <input type="hidden" name="source" value="{{ filters.source }}">
+            <input type="hidden" name="sort" value="{{ filters.sort }}">
+            <input type="hidden" name="direction" value="{{ filters.direction }}">
+            {% if edit %}
+            <input type="hidden" name="edit" value="1">
+            {% end %}
+            <label class="bw-field">
+                <span>Status</span>
+                <select class="bw-select" name="status" onchange="this.form.requestSubmit()">
+                    <option value="all" {% if filters.status == "all" %}selected{% end %}>All</option>
+                    <option value="running" {% if filters.status == "running" %}selected{% end %}>Running</option>
+                    <option value="caught" {% if filters.status == "caught" %}selected{% end %}>Caught</option>
+                    <option value="idle" {% if filters.status == "idle" %}selected{% end %}>Idle</option>
+                    <option value="stale" {% if filters.status == "stale" %}selected{% end %}>Stale</option>
+                    <option value="done" {% if filters.status == "done" %}selected{% end %}>Done</option>
+                    <option value="error" {% if filters.status == "error" %}selected{% end %}>Error</option>
+                </select>
+            </label>
+        </form>
+
+        <form class="bw-select-form" action="/" method="get" hx-get="/workspaces"
+            hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
+            hx-vals='{"push_url":"1"}'>
+            <input type="hidden" name="group" value="{{ filters.group }}">
+            <input type="hidden" name="search" value="{{ filters.search }}">
+            <input type="hidden" name="status" value="{{ filters.status }}">
+            <input type="hidden" name="sort" value="{{ filters.sort }}">
+            <input type="hidden" name="direction" value="{{ filters.direction }}">
+            {% if edit %}
+            <input type="hidden" name="edit" value="1">
+            {% end %}
+            <label class="bw-field">
+                <span>Source</span>
+                <select class="bw-select" name="source" onchange="this.form.requestSubmit()">
+                    <option value="all" {% if filters.source == "all" %}selected{% end %}>All</option>
+                    <option value="jenkins" {% if filters.source == "jenkins" %}selected{% end %}>Jenkins</option>
+                    <option value="deployment" {% if filters.source == "deployment" %}selected{% end %}>Deployment</option>
+                    <option value="local" {% if filters.source == "local" %}selected{% end %}>Local</option>
+                </select>
+            </label>
+        </form>
+
+        <div class="bw-filter-actions">
+            {% if edit %}
+            <a class="bw-button bw-button-secondary" href="{{ canonical_url(filters) }}"
+                hx-get="{{ partial_url(filters, push_url=True) }}" hx-target="closest .bw-frame"
+                hx-swap="innerHTML" hx-push-url="false">Exit edit</a>
+            {% else %}
+            <a class="bw-button bw-button-secondary" href="{{ canonical_url(filters, edit=True) }}"
+                hx-get="{{ partial_url(filters, edit=True, push_url=True) }}" hx-target="closest .bw-frame"
+                hx-swap="innerHTML" hx-push-url="false">Edit</a>
+            {% end %}
         </div>
     </div>
-</div>
-{% end %}
-{% for workspace_name, workspace in sorted(workspaces.items()) %}
-<div class="row pb-2">
-    <div class="container bg-light border border-dark rounded">
-        <div class="row pt-2 pb-2 border-bottom border-dark">
-            <div class="col-xxl-4 col-xl-5 col-l-12">
-                <span class="h3 workspace-title" id="{{ workspace_name }}">{{ workspace_name }}</span>
+
+    {% if orphan_auth_prompts %}
+    <section class="bw-notice">
+        <div class="bw-notice-title">Active authentication prompts</div>
+        {% for prompt in orphan_auth_prompts %}
+        <div class="bw-notice-row" title="{{ prompt.created_time }}">
+            <span>{% if prompt.workspace %}{{ prompt.workspace }}{% else %}&lt;unknown workspace&gt;{% end %}</span>
+            <span>{% if prompt.auth_context.get('worker_command') %}{{ prompt.auth_context.get('worker_command') }}{% else %}&lt;unknown command&gt;{% end %}</span>
+            <span>{% if prompt.auth_context.get('worker_limit') %}{{ prompt.auth_context.get('worker_limit') }}{% else %}&lt;unknown limit&gt;{% end %}</span>
+            {% if prompt.auth_context.get('deployment_url') %}
+            <a href="{{ prompt.auth_context.get('deployment_url') # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}">Deployment</a>
+            {% else %}
+            <span>Deployment unavailable</span>
+            {% end %}
+            <a href="{{ prompt.login_url # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}" class="bw-button bw-button-catch">Open login</a>
+        </div>
+        {% end %}
+    </section>
+    {% end %}
+
+    <div class="bw-lanes">
+        {% if not dashboard.rows %}
+        <div class="bw-empty">
+            <strong>No workspaces match these filters.</strong>
+            <span>{{ dashboard.total_count }} visible workspace{% if dashboard.total_count != 1 %}s{% end %}</span>
+        </div>
+        {% end %}
+
+        {% for lane in dashboard.lanes %}
+        <section class="bw-lane bw-lane-{{ lane.key }}">
+            <div class="bw-lane-header">
+                <h2>{{ lane.label }}</h2>
+                <span>{{ lane.count }} workspace{% if lane.count != 1 %}s{% end %}</span>
             </div>
-            <div class="col col-xxl-7 col-xl-6 col-l-6 col-sm-6 col-10">
-                <span class="h4 ms-1">
-                    {% if secondsdelta(workspace.last_seen) > 10 %}
-                    <span
-                        title="No worker connected to this workspace. Last seen {{ workspace.last_seen }} (UTC)">⚪️</span>
-                    {% else %}
-                    <span title="Worker is connected to this workspace">🟢</span>
+
+            <div class="bw-table" role="table" aria-label="{{ lane.label }} workspaces">
+                <div class="bw-head" role="row">
+                    <span class="bw-head-stack">
+                        <span class="bw-sort">
+                            <span class="bw-sort-label">Workspace</span>
+                            <a class="bw-sort-arrow{% if filters.sort == "workspace" %} is-active{% end %}"
+                                href="{{ sort_url("/", filters, "workspace", edit=edit) }}"
+                                hx-get="{{ sort_url("/workspaces", filters, "workspace", edit=edit, push_url="1") }}"
+                                hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
+                                aria-label="{% if filters.sort == "workspace" %}Workspace sorted {{ filters.direction }}; switch sort direction{% else %}Workspace sorted by default; sort by workspace{% end %}">
+                                <span aria-hidden="true">{% if filters.sort == "workspace" %}{% if filters.direction == "asc" %}&uarr;{% else %}&darr;{% end %}{% else %}&#8597;{% end %}</span>
+                            </a>
+                        </span>
+                        <span class="bw-sort bw-sort-subtle">
+                            <span class="bw-sort-label">Latest</span>
+                            <a class="bw-sort-arrow{% if filters.sort == "updated" %} is-active{% end %}"
+                                href="{{ sort_url("/", filters, "updated", edit=edit) }}"
+                                hx-get="{{ sort_url("/workspaces", filters, "updated", edit=edit, push_url="1") }}"
+                                hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
+                                aria-label="{% if filters.sort == "updated" %}Latest event sorted {{ filters.direction }}; switch sort direction{% else %}Latest event sorted by default; sort by latest event{% end %}">
+                                <span aria-hidden="true">{% if filters.sort == "updated" %}{% if filters.direction == "asc" %}&uarr;{% else %}&darr;{% end %}{% else %}&#8597;{% end %}</span>
+                            </a>
+                        </span>
+                    </span>
+                    <span>Limit</span>
+                    <span class="bw-sort">
+                        <span class="bw-sort-label">Current host</span>
+                        <a class="bw-sort-arrow{% if filters.sort == "current_host" %} is-active{% end %}"
+                            href="{{ sort_url("/", filters, "current_host", edit=edit) }}"
+                            hx-get="{{ sort_url("/workspaces", filters, "current_host", edit=edit, push_url="1") }}"
+                            hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
+                            aria-label="{% if filters.sort == "current_host" %}Current host sorted {{ filters.direction }}; switch sort direction{% else %}Current host sorted by default; sort by current host{% end %}">
+                            <span aria-hidden="true">{% if filters.sort == "current_host" %}{% if filters.direction == "asc" %}&uarr;{% else %}&darr;{% end %}{% else %}&#8597;{% end %}</span>
+                        </a>
+                    </span>
+                    <span class="bw-sort">
+                        <span class="bw-sort-label">Source</span>
+                        <a class="bw-sort-arrow{% if filters.sort == "source" %} is-active{% end %}"
+                            href="{{ sort_url("/", filters, "source", edit=edit) }}"
+                            hx-get="{{ sort_url("/workspaces", filters, "source", edit=edit, push_url="1") }}"
+                            hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
+                            aria-label="{% if filters.sort == "source" %}Source sorted {{ filters.direction }}; switch sort direction{% else %}Source sorted by default; sort by source{% end %}">
+                            <span aria-hidden="true">{% if filters.sort == "source" %}{% if filters.direction == "asc" %}&uarr;{% else %}&darr;{% end %}{% else %}&#8597;{% end %}</span>
+                        </a>
+                    </span>
+                    <span class="bw-sort">
+                        <span class="bw-sort-label">Status</span>
+                        <a class="bw-sort-arrow{% if filters.sort == "status" %} is-active{% end %}"
+                            href="{{ sort_url("/", filters, "status", edit=edit) }}"
+                            hx-get="{{ sort_url("/workspaces", filters, "status", edit=edit, push_url="1") }}"
+                            hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
+                            aria-label="{% if filters.sort == "status" %}Status sorted {{ filters.direction }}; switch sort direction{% else %}Status sorted by default; sort by status{% end %}">
+                            <span aria-hidden="true">{% if filters.sort == "status" %}{% if filters.direction == "asc" %}&uarr;{% else %}&darr;{% end %}{% else %}&#8597;{% end %}</span>
+                        </a>
+                    </span>
+                    <span>Actions</span>
+                </div>
+
+        {% for row in lane.rows %}
+        {% set workspace_name = row.name %}
+        {% set workspace = workspaces.get(row.name) %}
+        {% set detail_id = "workspace-details-" + sha256(row.name) %}
+        {% set workspace_key = sha256(row.name) %}
+        <div class="bw-row status-{{ row.status }}" role="row" data-workspace-row
+            data-workspace-key="{{ workspace_key }}">
+            <div class="bw-cell-main" role="cell">
+                <button type="button" class="bw-expand" data-row-toggle data-workspace-key="{{ workspace_key }}"
+                    aria-controls="{{ detail_id }}" aria-expanded="false" title="Expand {{ row.name }}">
+                    <span aria-hidden="true">›</span>
+                    <span class="bw-sr-only">Expand {{ row.name }}</span>
+                </button>
+                <div class="bw-workspace-title">
+                    <span class="bw-workspace-name" data-fit-name title="{{ row.name }}">{{ row.name }}</span>
+                    <span class="bw-latest" title="{{ row.latest_event }}">{% if row.latest_event %}{{ row.latest_event }}{% else %}No recent event{% end %}</span>
+                    {% if row.advice %}
+                    <span class="bw-advice-list">
+                        {% for advice in row.advice %}
+                        <span class="bw-advice-pill">{{ advice.name }}</span>
+                        {% end %}
+                    </span>
                     {% end %}
-                    {% if workspace.semaphores.has_mutex %}
-                    <span title="Worker has boardwalkd's server-side workspace mutex">🔒</span>
-                    {% else %}
-                    <span title="No worker has boardwalkd's server-side workspace mutex">🔓</span>
-                    {% end %}
+                </div>
+            </div>
+            <div class="bw-cell bw-mono" role="cell" data-fit-name title="{{ row.limit_pattern }}">{{ row.limit_pattern }}</div>
+            <div class="bw-cell bw-host" role="cell">
+                <span data-fit-name title="{{ row.current_host }}">{% if row.current_host %}{{ row.current_host }}{% else %}unknown{% end %}</span>
+            </div>
+            <div class="bw-source" role="cell">
+                {% if row.source_url %}
+                <a href="{{ row.source_url # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}" target="_blank" rel="noreferrer">{{ row.source_label }}</a>
+                {% else %}
+                <span class="bw-source-label">{{ row.source_label }}</span>
+                {% end %}
+                <span class="bw-source-user">{{ row.user }}</span>
+            </div>
+            <div role="cell">
+                <span class="bw-status status-{{ row.status }}">
+                    <span class="bw-status-dot" aria-hidden="true"></span>
+                    {{ row.status }}
                 </span>
             </div>
-            <div class="col-xxl-1 col-xl-1 col-l-6 col-sm-6 col-2 text-end">
-                {% if workspace.semaphores.caught %}
+            <div class="bw-actions-cell" role="cell">
+                {% if row.caught %}
                 {% include "index_workspace_release.html" %}
                 {% else %}
                 {% include "index_workspace_catch.html" %}
                 {% end %}
             </div>
         </div>
-        {% if workspace_name in auth_prompts_by_workspace %}
-        <div class="row border-bottom border-warning bg-warning-subtle">
-            <div class="col pt-2 pb-2">
-                {% for prompt in auth_prompts_by_workspace[workspace_name] %}
-                <div class="d-flex flex-wrap gap-2 align-items-center" title="{{ prompt.created_time }}">
+
+        <section id="{{ detail_id }}" class="bw-row-details status-{{ row.status }}"
+            data-workspace-key="{{ workspace_key }}" hidden>
+            {% if row.name in auth_prompts_by_workspace %}
+            <div class="bw-auth-prompts">
+                {% for prompt in auth_prompts_by_workspace[row.name] %}
+                <div class="bw-notice-row" title="{{ prompt.created_time }}">
                     <strong>Auth required</strong>
                     {% if prompt.auth_context.get('worker_command') %}
                     <span>Command: {{ prompt.auth_context.get('worker_command') }}</span>
@@ -110,129 +256,135 @@
                     {% if prompt.auth_context.get('deployment_url') %}
                     <a href="{{ prompt.auth_context.get('deployment_url') # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}">Deployment</a>
                     {% end %}
-                    <a href="{{ prompt.login_url # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}" class="btn btn-sm btn-warning">Open login</a>
+                    <a href="{{ prompt.login_url # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}" class="bw-button bw-button-catch">Open login</a>
                 </div>
                 {% end %}
             </div>
-        </div>
-        {% end %}
-        <div class="row">
-            <div class="col-xxl-4 col-xl-5">
-                <table class="table workspace-details-table">
-                    <tbody>
-                        <tr>
-                            <th scope="row">Workflow</th>
-                            <td>{{ workspace.details.workflow }}</td>
-                        </tr>
-                        <tr>
-                            <th scope="row">Worker</th>
-                            <td>{{ workspace.details.worker_username }}@{{ workspace.details.worker_hostname }}</td>
-                        </tr>
-                        <tr>
-                            <th scope="row">Host Pattern</th>
-                            <td>{{ workspace.details.host_pattern }}</td>
-                        </tr>
-                        <tr>
-                            <th scope="row" title="An additional --limit applied to this workspace's Host Pattern">
-                                <span class="context-underline">Limit Pattern</span>
-                            </th>
-                            <td>
-                                {% if not workspace.details.worker_limit %}
-                                    <span class="context-underline" title="A limit was not provided--thus equivalent to 'all'--or the worker client is old and did not send a limit">&lt;unknown&gt;</span>
-                                {% else %}
-                                    {{ workspace.details.worker_limit }}
-                                {% end %}
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">Command</th>
-                            <td>{{ workspace.details.worker_command }}</td>
-                        </tr>
-                        {% if workspace.semaphores.caught %}
-                        <tr>
-                            <th scope="row" title="Request that the connected worker removes /etc/ansible/facts.d/boardwalk_state.fact from the current host">
-                                <span class="context-underline">Remote State</span>
-                            </th>
-                            <td>
-                                {% include "index_workspace_remote_state_clear.html" %}
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row" title="Request that the connected worker removes /opt/boardwalk.mutex from the current target host">
-                                <span class="context-underline">Host Mutex</span>
-                            </th>
-                            <td>
-                                {% include "index_workspace_remote_mutex_clear.html" %}
-                            </td>
-                        </tr>
-                        {% end %}
-                    </tbody>
-                </table>
-            </div>
-            <div class="col-xxl-8 col-xl-7 workspace-events-preview-col">
-                <div class="workspace-events-container">
-                    <table class="table table-borderless">
-                        <tbody>
-                            {% for event in sort_events_by_date(workspace.events)[:6] %}
-                            {% if event.severity == "info" %}
-                            <tr title="{{ event.create_time }}">
-                                <td>{{ event.severity }}</td>
-                                <td>{{ squeeze(event.message) }}</td>
-                            </tr>
-                            {% end %}
-                            {% if event.severity == "success" %}
-                            <tr title="{{ event.create_time }}" class="border-end border-2 border-success">
-                                <td>{{ event.severity }}</td>
-                                <td>{{ squeeze(event.message) }}</td>
-                            </tr>
-                            {% end %}
-                            {% if event.severity == "error" %}
-                            <tr title="{{ event.create_time }}" class="border-end border-2 border-danger">
-                                <td>{{ event.severity }}</td>
-                                <td>{{ squeeze(event.message) }}</td>
-                            </tr>
-                            {% end %}
-                            {% end %}
-                        </tbody>
-                    </table>
+            {% end %}
+
+            {% if row.advice %}
+            <div class="bw-advice-detail">
+                <span class="bw-detail-label">Advice</span>
+                {% for advice in row.advice %}
+                <div class="bw-advice-message">
+                    <strong>{{ advice.name }}</strong>
+                    <span>{{ advice.message }}</span>
                 </div>
-                <a href="/workspace/{{ workspace_name }}/events" class="more-events btn btn-sm btn-secondary"
-                    aria-current="More events" title="More events"
-                    style="--bs-btn-padding-y: .25rem; --bs-btn-padding-x: .5rem; --bs-btn-font-size: .75rem;">More</a>
+                {% end %}
             </div>
-        </div>
-        {% if edit %}
-        <div class="row pt-2 pb-2 border-top border-dark">
-            <div class="btn-group btn-group-sm" role="edit group" aria-label="edit button group">
-                {% if secondsdelta(workspace.last_seen) < 10 %} <button type="button" class="btn btn-danger"
-                    title="Clears boardwalkd's server-side workspace mutex. Does not remove /opt/boardwalk.mutex from target hosts. Disabled while a worker is connected."
-                    disabled>Clear workspace
-                    mutex</button>
-                    {% elif workspace.semaphores.has_mutex %}
-                    <button type="button" class="btn btn-danger"
-                        title="Clears boardwalkd's server-side workspace mutex. Does not remove /opt/boardwalk.mutex from target hosts."
-                        hx-delete="/workspace/{{ workspace_name }}/semaphores/has_mutex" hx-trigger="click"
-                        hx-confirm="Clear boardwalkd's server-side workspace mutex for &quot;{{ workspace_name }}&quot;? This does not remove /opt/boardwalk.mutex from target hosts.">Clear workspace
-                        mutex</button>
-                    {% else %}
-                    <button type="button" class="btn btn-danger"
-                        title="Clears boardwalkd's server-side workspace mutex. Does not remove /opt/boardwalk.mutex from target hosts."
-                        disabled>Clear workspace
-                        mutex</button>
+            {% end %}
+
+            <div class="bw-detail-grid">
+                <div class="bw-detail">
+                    <span class="bw-detail-label">Worker</span>
+                    <span class="bw-detail-value bw-mono">{{ row.worker }}</span>
+                </div>
+                <div class="bw-detail">
+                    <span class="bw-detail-label">Host pattern</span>
+                    <span class="bw-detail-value bw-mono">{{ row.host_pattern }}</span>
+                </div>
+                <div class="bw-detail">
+                    <span class="bw-detail-label">Workflow</span>
+                    <span class="bw-detail-value">{{ row.workflow }}</span>
+                </div>
+                <div class="bw-detail">
+                    <span class="bw-detail-label">Current host</span>
+                    <span class="bw-detail-value bw-mono">{% if row.current_host %}{{ row.current_host }}{% else %}unknown{% end %}</span>
+                </div>
+                <div class="bw-detail bw-detail-wide">
+                    <span class="bw-detail-label">Command</span>
+                    <span class="bw-detail-value bw-command">{{ row.command }}</span>
+                </div>
+            </div>
+
+            <div class="bw-events">
+                <div class="bw-events-header">
+                    <span>Recent events</span>
+                    {% if len(row.events) > 6 %}
+                    <button type="button" class="bw-events-more" data-events-toggle>
+                        Show {{ len(row.events) - 6 }} more
+                    </button>
                     {% end %}
-                    {% if workspace.semaphores.has_mutex or secondsdelta(workspace.last_seen) < 10 %} <button
-                        type="button" class="btn btn-danger" title="Deletes the workspace data from the server"
-                        disabled>Delete
-                        workspace</button>
-                        {% else %}
-                        <button type="button" class="btn btn-danger" title="Deletes the workspace data from the server"
-                            hx-post="/workspace/{{ workspace_name }}/delete" hx-trigger="click"
-                            hx-confirm="Are you sure you want to delete the workspace &quot;{{ workspace_name }}&quot; from the server?">Delete
-                            workspace</button>
-                        {% end %}
+                </div>
+                {% if row.events %}
+                {% for event in row.events[:6] %}
+                <div class="bw-event-line severity-{{ event.severity }}" title="{{ event.create_time }}">
+                    <span>{{ event.severity }}</span>
+                    <span>{{ squeeze(event.message) }}</span>
+                </div>
+                {% end %}
+                {% for event in row.events[6:] %}
+                <div class="bw-event-line severity-{{ event.severity }}" title="{{ event.create_time }}" hidden
+                    data-event-extra>
+                    <span>{{ event.severity }}</span>
+                    <span>{{ squeeze(event.message) }}</span>
+                </div>
+                {% end %}
+                {% else %}
+                <div class="bw-event-line">
+                    <span>info</span>
+                    <span>No recent events</span>
+                </div>
+                {% end %}
             </div>
-        </div>
+
+            {% if row.can_request_remote_cleanup and workspace %}
+            <div class="bw-cleanup-actions">
+                <span class="bw-detail-label">Remote cleanup</span>
+                {% include "index_workspace_remote_state_clear.html" %}
+                {% include "index_workspace_remote_mutex_clear.html" %}
+            </div>
+            {% end %}
+
+            {% if edit and workspace %}
+            {% set worker_active = row.worker_connected %}
+            <div class="bw-edit-actions">
+                <span class="bw-detail-label">Admin</span>
+                {% if worker_active %}
+                <button type="button" class="bw-button bw-button-danger" disabled
+                    title="Disabled while a worker is connected">
+                    Clear workspace mutex
+                </button>
+                {% elif workspace.semaphores.has_mutex %}
+                <button type="button" class="bw-button bw-button-danger"
+                    title="Clears boardwalkd's server-side workspace mutex. Does not remove /opt/boardwalk.mutex from target hosts."
+                    hx-delete="{{ action_url('/workspace/' + workspace_name + '/semaphores/has_mutex', filters, edit=edit) }}"
+                    hx-trigger="click" hx-target="closest .bw-frame" hx-swap="innerHTML"
+                    hx-push-url="false"
+                    hx-confirm="Clear boardwalkd's server-side workspace mutex for &quot;{{ workspace_name }}&quot;? This does not remove /opt/boardwalk.mutex from target hosts.">
+                    Clear workspace mutex
+                </button>
+                {% else %}
+                <button type="button" class="bw-button bw-button-danger" disabled
+                    title="No server-side workspace mutex is present">
+                    Clear workspace mutex
+                </button>
+                {% end %}
+
+                {% if workspace.semaphores.has_mutex or worker_active %}
+                <button type="button" class="bw-button bw-button-danger" disabled title="Deletes the workspace data from the server">
+                    Delete workspace
+                </button>
+                {% else %}
+                <button type="button" class="bw-button bw-button-danger" title="Deletes the workspace data from the server"
+                    hx-post="{{ action_url('/workspace/' + workspace_name + '/delete', filters, edit=edit) }}"
+                    hx-trigger="click" hx-target="closest .bw-frame" hx-swap="innerHTML"
+                    hx-push-url="false"
+                    hx-confirm="Are you sure you want to delete the workspace &quot;{{ workspace_name }}&quot; from the server?">
+                    Delete workspace
+                </button>
+                {% end %}
+            </div>
+            {% end %}
+        </section>
+        {% end %}
+            </div>
+        </section>
         {% end %}
     </div>
+
+    <footer class="bw-toolbar">
+        <span>{{ dashboard.total_count }} visible workspace{% if dashboard.total_count != 1 %}s{% end %}</span>
+        <span>{{ dashboard.running_count }} running · {{ dashboard.caught_count }} caught · {{ dashboard.done_count }} done · {{ dashboard.stale_count }} stale · {{ dashboard.error_count }} error</span>
+    </footer>
 </div>
-{% end %}

--- a/src/boardwalkd/templates/index_workspace_catch.html
+++ b/src/boardwalkd/templates/index_workspace_catch.html
@@ -1,4 +1,6 @@
-<button class="btn btn-sm btn-outline-warning" hx-post="/workspace/{{ workspace_name }}/semaphores/caught"
-    hx-trigger="click" hx-swap="outerHTML" title="&quot;Catch&quot; the workflow before the next host">
+<button type="button" class="bw-button bw-button-catch"
+    hx-post="{{ action_url('/workspace/' + workspace_name + '/semaphores/caught', filters, edit=edit) }}"
+    hx-trigger="click" hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
+    title="Catch the workflow before the next host">
     Catch
 </button>

--- a/src/boardwalkd/templates/index_workspace_release.html
+++ b/src/boardwalkd/templates/index_workspace_release.html
@@ -1,4 +1,6 @@
-<button class="btn btn-sm btn-warning" hx-delete="/workspace/{{ workspace_name }}/semaphores/caught" hx-trigger="click"
-    hx-swap="outerHTML" title="Release the workflow catch and allow moving to next host">
+<button type="button" class="bw-button bw-button-release"
+    hx-delete="{{ action_url('/workspace/' + workspace_name + '/semaphores/caught', filters, edit=edit) }}"
+    hx-trigger="click" hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
+    title="Release the workflow catch and allow moving to next host">
     Release
 </button>

--- a/src/boardwalkd/templates/index_workspace_remote_mutex_clear.html
+++ b/src/boardwalkd/templates/index_workspace_remote_mutex_clear.html
@@ -1,18 +1,18 @@
-<div id="remote-mutex-clear-{{ sha256(workspace_name) }}" class="d-flex flex-wrap gap-2 align-items-center">
+<div id="remote-mutex-clear-{{ sha256(workspace_name) }}" class="bw-cleanup-control">
     {% if workspace.semaphores.clear_remote_mutex_requested %}
-    <span class="badge text-bg-warning">Cleanup requested</span>
-    {% elif secondsdelta(workspace.last_seen) > 10 %}
-    <button type="button" class="btn btn-sm btn-outline-danger"
-        title="A connected worker is required to remove /opt/boardwalk.mutex from the current target host" disabled>
-        Clear host mutex
+    <span class="bw-badge bw-badge-caught">Cleanup requested</span>
+    {% elif not workspace.last_seen or secondsdelta(workspace.last_seen) > 10 %}
+    <button type="button" class="bw-button bw-button-secondary" disabled
+        title="A connected worker is required to remove /opt/boardwalk.mutex from the current target host">
+        Clear remote host mutex
     </button>
     {% else %}
-    <button type="button" class="btn btn-sm btn-outline-danger"
+    <button type="button" class="bw-button bw-button-secondary"
         title="Request that the connected worker removes /opt/boardwalk.mutex from the current target host"
         hx-post="/workspace/{{ workspace_name }}/remote_mutex/clear" hx-trigger="click"
         hx-target="#remote-mutex-clear-{{ sha256(workspace_name) }}" hx-swap="outerHTML"
         hx-confirm="Request the connected worker to remove /opt/boardwalk.mutex from the current target host?">
-        Clear host mutex
+        Clear remote host mutex
     </button>
     {% end %}
 </div>

--- a/src/boardwalkd/templates/index_workspace_remote_state_clear.html
+++ b/src/boardwalkd/templates/index_workspace_remote_state_clear.html
@@ -1,18 +1,18 @@
-<div id="remote-state-clear-{{ sha256(workspace_name) }}" class="d-flex flex-wrap gap-2 align-items-center">
+<div id="remote-state-clear-{{ sha256(workspace_name) }}" class="bw-cleanup-control">
     {% if workspace.semaphores.clear_remote_state_requested %}
-    <span class="badge text-bg-warning">Cleanup requested</span>
-    {% elif secondsdelta(workspace.last_seen) > 10 %}
-    <button type="button" class="btn btn-sm btn-outline-danger"
-        title="A connected worker is required to remove the remote state fact" disabled>
-        Clear state fact
+    <span class="bw-badge bw-badge-caught">Cleanup requested</span>
+    {% elif not workspace.last_seen or secondsdelta(workspace.last_seen) > 10 %}
+    <button type="button" class="bw-button bw-button-secondary" disabled
+        title="A connected worker is required to remove the remote Boardwalk fact file">
+        Clear remote Boardwalk fact file
     </button>
     {% else %}
-    <button type="button" class="btn btn-sm btn-outline-danger"
+    <button type="button" class="bw-button bw-button-secondary"
         title="Request that the connected worker removes /etc/ansible/facts.d/boardwalk_state.fact from the current host"
         hx-post="/workspace/{{ workspace_name }}/remote_state/clear" hx-trigger="click"
         hx-target="#remote-state-clear-{{ sha256(workspace_name) }}" hx-swap="outerHTML"
         hx-confirm="Request the connected worker to remove /etc/ansible/facts.d/boardwalk_state.fact from the current host?">
-        Clear state fact
+        Clear remote Boardwalk fact file
     </button>
     {% end %}
 </div>

--- a/src/boardwalkd/utils.py
+++ b/src/boardwalkd/utils.py
@@ -19,10 +19,18 @@ def list_active_workspaces(last_seen_seconds: int = 10, _sorted: bool = True) ->
         return workspaces
 
 
-def is_workspace_active(workspace_name: str, last_seen_seconds: int = 10) -> bool:
-    """Returns Boolean True if the provided workspace name is active, based on the configured `last_seen_seconds` value."""
+def is_workspace_active(workspace_name: str, last_seen_seconds: int = 10, now: datetime | None = None) -> bool:
+    """Returns True if the workspace has had a recent heartbeat.
+
+    :param workspace_name: The workspace name to check for recent activity.
+    :param last_seen_seconds: Seconds since last heartbeat to consider active.
+    :param now: Optional datetime used for deterministic tests.
+    """
     if ws := server.state.workspaces.get(workspace_name):
-        if (datetime.now(UTC) - ws.last_seen.replace(tzinfo=UTC)).total_seconds() < last_seen_seconds:  # type: ignore
+        if not ws.last_seen:
+            return False
+        current_time = (now or datetime.now(UTC)).replace(tzinfo=UTC)
+        if (current_time - ws.last_seen.replace(tzinfo=UTC)).total_seconds() < last_seen_seconds:
             return True
     return False
 

--- a/test/boardwalk/test_cli_run.py
+++ b/test/boardwalk/test_cli_run.py
@@ -1,0 +1,238 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from boardwalk import Workflow, WorkspaceConfig, cli_run
+from boardwalk.ansible import ansible_runner_run_tasks
+from boardwalk.cli_run import (
+    build_workspace_details,
+    resolve_workspace_ui_group,
+    workspace_event_for_ansible_task_start,
+)
+from boardwalk.manifest import JobTypes
+
+
+class EmptyWorkflow(Workflow):
+    def jobs(self):
+        return ()
+
+
+class FakeBoardwalkdClient:
+    def __init__(self):
+        self.details = []
+        self.events = []
+
+    def post_details(self, details):
+        self.details.append(details)
+
+    def queue_event(self, event, broadcast=False):
+        self.events.append((event, broadcast))
+
+
+class FakeHost:
+    def __init__(self, name):
+        self.name = name
+
+    def release(self, become_password=None, check=False):
+        return None
+
+
+def context_with_limit(limit_value):
+    return SimpleNamespace(params={"limit": limit_value})
+
+
+def workspace_with_config(cfg):
+    return SimpleNamespace(
+        name="UpgradeNodes",
+        cfg=cfg,
+    )
+
+
+def test_resolve_workspace_ui_group_prefers_explicit_group():
+    cfg = WorkspaceConfig(
+        host_pattern="nodes",
+        workflow=EmptyWorkflow(),
+        ui_group="net",
+        ui_group_inventory_var="site_group",
+    )
+    workspace = workspace_with_config(cfg)
+
+    group = resolve_workspace_ui_group(
+        workspace=workspace,
+        current_host="node-alpha-a",
+        inventory_vars={"node-alpha-a": {"site_group": "alpha"}},
+    )
+
+    assert group == "net"
+
+
+def test_resolve_workspace_ui_group_reads_inventory_var_for_current_host():
+    cfg = WorkspaceConfig(
+        host_pattern="nodes",
+        workflow=EmptyWorkflow(),
+        ui_group_inventory_var="site_group",
+    )
+    workspace = workspace_with_config(cfg)
+
+    group = resolve_workspace_ui_group(
+        workspace=workspace,
+        current_host="node-alpha-a",
+        inventory_vars={"node-alpha-a": {"site_group": "alpha"}},
+    )
+
+    assert group == "alpha"
+
+
+def test_resolve_workspace_ui_group_returns_blank_without_host_or_var():
+    cfg = WorkspaceConfig(host_pattern="nodes", workflow=EmptyWorkflow())
+    workspace = workspace_with_config(cfg)
+
+    assert resolve_workspace_ui_group(workspace=workspace) == ""
+
+
+def test_resolve_workspace_ui_group_ignores_inventory_vars_when_no_var_configured():
+    cfg = WorkspaceConfig(host_pattern="nodes", workflow=EmptyWorkflow())
+    workspace = workspace_with_config(cfg)
+
+    group = resolve_workspace_ui_group(
+        workspace=workspace,
+        current_host="node-alpha-a",
+        inventory_vars={"node-alpha-a": {"unrelated_inventory_value": "alpha"}},
+    )
+
+    assert group == ""
+
+
+def test_build_workspace_details_includes_existing_fields_current_host_and_derived_group(monkeypatch):
+    monkeypatch.setattr(cli_run.socket, "gethostname", lambda: "worker-host")
+    monkeypatch.setattr(cli_run.getpass, "getuser", lambda: "worker-user")
+    monkeypatch.setenv("BUILD_URL", "https://build.example/job/1")
+    monkeypatch.setenv("BUILD_TAG", "build-tag")
+    monkeypatch.setenv("JOB_NAME", "boardwalk-refresh")
+    monkeypatch.setenv("BUILD_NUMBER", "42")
+    monkeypatch.setenv("BUILD_USER", "Builder")
+    monkeypatch.setenv("BUILD_USER_ID", "builder-id")
+    monkeypatch.setenv("BUILD_USER_EMAIL", "builder@example.com")
+    cfg = WorkspaceConfig(
+        host_pattern="nodes",
+        workflow=EmptyWorkflow(),
+        ui_group_inventory_var="site_group",
+    )
+    workspace = workspace_with_config(cfg)
+
+    details = build_workspace_details(
+        workspace=workspace,
+        ctx=context_with_limit("node-alpha-a"),
+        current_host="node-alpha-a",
+        inventory_vars={"node-alpha-a": {"site_group": "alpha"}},
+    )
+
+    assert details.deployment_url == "https://build.example/job/1"
+    assert details.deployment_name == "boardwalk-refresh"
+    assert details.deployment_number == "42"
+    assert details.deployment_tag == "build-tag"
+    assert details.deployment_user == "Builder"
+    assert details.deployment_user_id == "builder-id"
+    assert details.deployment_user_email == "builder@example.com"
+    assert details.host_pattern == "nodes"
+    assert details.workflow == "EmptyWorkflow"
+    assert details.worker_command in {"check", "run"}
+    assert details.worker_hostname == "worker-host"
+    assert details.worker_limit == "node-alpha-a"
+    assert details.worker_username == "worker-user"
+    assert details.current_host == "node-alpha-a"
+    assert details.ui_group == "alpha"
+
+
+def test_workspace_event_for_ansible_task_start_formats_role_task_name():
+    event = workspace_event_for_ansible_task_start(
+        hostname="node-alpha-a",
+        event_data={
+            "event": "playbook_on_task_start",
+            "event_data": {
+                "role": "network_setup",
+                "task": "Set sysctl values",
+            },
+        },
+    )
+
+    assert event is not None
+    assert event.severity == "info"
+    assert event.message == "node-alpha-a: Running Ansible task network_setup : Set sysctl values"
+
+
+def test_workspace_event_for_ansible_task_start_ignores_non_task_start_events():
+    event = workspace_event_for_ansible_task_start(
+        hostname="node-alpha-a",
+        event_data={
+            "event": "runner_on_ok",
+            "event_data": {
+                "role": "network_setup",
+                "task": "Set sysctl values",
+            },
+        },
+    )
+
+    assert event is None
+
+
+def test_run_workflow_posts_current_host_details_when_each_host_starts(monkeypatch):
+    client = FakeBoardwalkdClient()
+    monkeypatch.setattr(cli_run, "boardwalkd_client", client)
+    monkeypatch.setattr(cli_run, "handle_workflow_catch", lambda workspace, host: None)
+    monkeypatch.setattr(cli_run, "lock_remote_host", lambda host: None)
+    monkeypatch.setattr(cli_run, "directly_confirm_host_preconditions", lambda host, inventory_vars, workspace: True)
+    monkeypatch.setattr(cli_run, "execute_host_workflow", lambda host, workspace, verbosity: None)
+    monkeypatch.setattr(cli_run.socket, "gethostname", lambda: "worker-host")
+    monkeypatch.setattr(cli_run.getpass, "getuser", lambda: "worker-user")
+    cfg = WorkspaceConfig(
+        host_pattern="nodes",
+        workflow=EmptyWorkflow(),
+        ui_group_inventory_var="site_group",
+    )
+    workspace = workspace_with_config(cfg)
+    inventory_vars = {
+        "node-alpha-a": {"site_group": "alpha"},
+        "node-beta-a": {"site_group": "beta"},
+    }
+
+    cli_run.run_workflow(
+        hosts=[FakeHost("node-alpha-a"), FakeHost("node-beta-a")],
+        inventory_vars=inventory_vars,
+        workspace=workspace,
+        verbosity=0,
+        ctx=context_with_limit("node-*"),
+    )
+
+    assert [details.current_host for details in client.details] == [
+        "node-alpha-a",
+        "node-beta-a",
+    ]
+    assert [details.ui_group for details in client.details] == ["alpha", "beta"]
+
+
+def test_ansible_runner_run_tasks_passes_event_handler_to_ansible_runner(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_get_ws():
+        return SimpleNamespace(path=tmp_path)
+
+    def fake_run(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(rc=0, events=[])
+
+    def event_handler(event_data):
+        return True
+
+    monkeypatch.setattr("boardwalk.manifest.get_ws", fake_get_ws)
+    monkeypatch.setattr("boardwalk.ansible.ansible_runner.run", fake_run)
+    monkeypatch.chdir(Path("/"))
+
+    ansible_runner_run_tasks(
+        hosts="node-alpha-a",
+        invocation_msg="main_TASK_Job_StopServiceJob",
+        job_type=JobTypes.TASK,
+        tasks=[{"name": "Stop service", "ansible.builtin.debug": {"msg": "stop"}}],
+        event_handler=event_handler,
+    )
+
+    assert captured["event_handler"] is event_handler

--- a/test/boardwalk/test_cli_run.py
+++ b/test/boardwalk/test_cli_run.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 
 from boardwalk import Workflow, WorkspaceConfig, cli_run
 from boardwalk.ansible import ansible_runner_run_tasks
@@ -36,11 +37,11 @@ class FakeHost:
         return None
 
 
-def context_with_limit(limit_value):
+def context_with_limit(limit_value) -> Any:
     return SimpleNamespace(params={"limit": limit_value})
 
 
-def workspace_with_config(cfg):
+def workspace_with_config(cfg) -> Any:
     return SimpleNamespace(
         name="UpgradeNodes",
         cfg=cfg,
@@ -196,7 +197,7 @@ def test_run_workflow_posts_current_host_details_when_each_host_starts(monkeypat
     }
 
     cli_run.run_workflow(
-        hosts=[FakeHost("node-alpha-a"), FakeHost("node-beta-a")],
+        hosts=cast(Any, [FakeHost("node-alpha-a"), FakeHost("node-beta-a")]),
         inventory_vars=inventory_vars,
         workspace=workspace,
         verbosity=0,

--- a/test/boardwalk/test_manifest.py
+++ b/test/boardwalk/test_manifest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from boardwalk import Job, PlaybookJob, TaskJob, Workflow, WorkspaceConfig
-from boardwalk.manifest import JobTypes, get_boardwalkd_url
+from boardwalk.manifest import JobTypes
 
 
 class EmptyWorkflow(Workflow):
@@ -74,10 +74,3 @@ def test_workspace_config_accepts_generic_inventory_var_grouping():
 
     assert cfg.ui_group == ""
     assert cfg.ui_group_inventory_var == "site_group"
-
-
-def test_get_boardwalkd_url_prefers_environment_override(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv("BOARDWALKD_URL", "http://localhost:8888/")
-
-    assert get_boardwalkd_url() == "http://localhost:8888/"

--- a/test/boardwalk/test_manifest.py
+++ b/test/boardwalk/test_manifest.py
@@ -1,7 +1,12 @@
 import pytest
 
-from boardwalk import Job, PlaybookJob, TaskJob
-from boardwalk.manifest import JobTypes
+from boardwalk import Job, PlaybookJob, TaskJob, Workflow, WorkspaceConfig
+from boardwalk.manifest import JobTypes, get_boardwalkd_url
+
+
+class EmptyWorkflow(Workflow):
+    def jobs(self):
+        return ()
 
 
 @pytest.mark.parametrize(
@@ -47,3 +52,32 @@ def test_using_not_differentiated_Job_class_warns_about_deprecation():
                 return [{"ansible.builtin.debug": {"msg": "Hello, Boardwalk!"}}]
 
         TestJob()
+
+
+def test_workspace_config_accepts_explicit_ui_group():
+    cfg = WorkspaceConfig(
+        host_pattern="localhost",
+        workflow=EmptyWorkflow(),
+        ui_group="alpha",
+    )
+
+    assert cfg.ui_group == "alpha"
+    assert cfg.ui_group_inventory_var == ""
+
+
+def test_workspace_config_accepts_generic_inventory_var_grouping():
+    cfg = WorkspaceConfig(
+        host_pattern="localhost",
+        workflow=EmptyWorkflow(),
+        ui_group_inventory_var="site_group",
+    )
+
+    assert cfg.ui_group == ""
+    assert cfg.ui_group_inventory_var == "site_group"
+
+
+def test_get_boardwalkd_url_prefers_environment_override(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BOARDWALKD_URL", "http://localhost:8888/")
+
+    assert get_boardwalkd_url() == "http://localhost:8888/"

--- a/test/boardwalkd/test_boardwalkd_cli.py
+++ b/test/boardwalkd/test_boardwalkd_cli.py
@@ -8,6 +8,22 @@ from click.testing import CliRunner
 from boardwalkd import cli
 
 
+class ImmediateEvent:
+    async def wait(self):
+        return None
+
+
+def invoke_serve_with_run_mock(args: list[str], runner: CliRunner | None = None):
+    runner = runner or CliRunner()
+    with (
+        patch("boardwalkd.cli.run", new_callable=AsyncMock) as run_mock,
+        patch("boardwalkd.cli.asyncio.Event", return_value=ImmediateEvent()),
+    ):
+        run_mock.return_value = (object(), [])
+        result = runner.invoke(cli=cli.serve, args=args)
+    return result, run_mock
+
+
 def test_version():
     """Running `boardwalkd version` should return the version of `boardwalk`."""
     runner = CliRunner()
@@ -47,24 +63,24 @@ async def test_incomplete_serve_command(
 def test_serve_passes_theme_options_to_server_run():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        with patch("boardwalkd.cli.run", new_callable=AsyncMock) as run_mock:
-            result = runner.invoke(
-                cli=cli.serve,
-                args=[
-                    "--host-header-pattern=(localhost|127\\.0\\.0\\.1)",
-                    "--port=8888",
-                    "--url=http://localhost:8888",
-                    "--theme-static-path=.",
-                    "--theme-css-url=/theme-static/boardwalkd-custom.css",
-                    "--theme-logo-url=/theme-static/custom-logo.svg",
-                    "--theme-logo-alt=Example",
-                    "--theme-brand-name=Boardwalk",
-                    "--jenkins-job-url=https://ci.example/job/boardwalk/",
-                ],
-            )
+        result, run_mock = invoke_serve_with_run_mock(
+            [
+                "--host-header-pattern=(localhost|127\\.0\\.0\\.1)",
+                "--port=8888",
+                "--url=http://localhost:8888",
+                "--theme-static-path=.",
+                "--theme-css-url=/theme-static/boardwalkd-custom.css",
+                "--theme-logo-url=/theme-static/custom-logo.svg",
+                "--theme-logo-alt=Example",
+                "--theme-brand-name=Boardwalk",
+                "--jenkins-job-url=https://ci.example/job/boardwalk/",
+            ],
+            runner=runner,
+        )
 
     assert result.exit_code == 0
     kwargs = run_mock.call_args.kwargs
+    assert kwargs["demo"] is False
     assert kwargs["theme_static_path"] == "."
     assert kwargs["theme_css_url"] == "/theme-static/boardwalkd-custom.css"
     assert kwargs["theme_logo_url"] == "/theme-static/custom-logo.svg"
@@ -73,23 +89,37 @@ def test_serve_passes_theme_options_to_server_run():
     assert kwargs["jenkins_job_url"] == "https://ci.example/job/boardwalk/"
 
 
+def test_serve_passes_demo_to_server_run():
+    result, run_mock = invoke_serve_with_run_mock(
+        [
+            "--demo",
+            "--host-header-pattern=(localhost|127\\.0\\.0\\.1)",
+            "--port=8888",
+            "--url=http://localhost:8888",
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert run_mock.call_args.kwargs["demo"] is True
+
+
 def test_serve_passes_develop_snapshot_to_server_run():
     runner = CliRunner()
     with runner.isolated_filesystem():
         open("snapshot.json", "w").write('{"workspaces": []}')
-        with patch("boardwalkd.cli.run", new_callable=AsyncMock) as run_mock:
-            result = runner.invoke(
-                cli=cli.serve,
-                args=[
-                    "--develop",
-                    "--develop-snapshot=snapshot.json",
-                    "--host-header-pattern=(localhost|127\\.0\\.0\\.1)",
-                    "--port=8888",
-                    "--url=http://localhost:8888",
-                ],
-            )
+        result, run_mock = invoke_serve_with_run_mock(
+            [
+                "--develop",
+                "--develop-snapshot=snapshot.json",
+                "--host-header-pattern=(localhost|127\\.0\\.0\\.1)",
+                "--port=8888",
+                "--url=http://localhost:8888",
+            ],
+            runner=runner,
+        )
 
     assert result.exit_code == 0
+    assert run_mock.call_args.kwargs["demo"] is False
     assert run_mock.call_args.kwargs["develop_snapshot_path"] == "snapshot.json"
 
 
@@ -109,6 +139,26 @@ def test_serve_rejects_develop_snapshot_without_develop():
 
     assert result.exit_code != 0
     assert "--develop-snapshot requires --develop" in result.output
+
+
+def test_serve_rejects_demo_with_develop_snapshot():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open("snapshot.json", "w").write('{"workspaces": []}')
+        result = runner.invoke(
+            cli=cli.serve,
+            args=[
+                "--develop",
+                "--demo",
+                "--develop-snapshot=snapshot.json",
+                "--host-header-pattern=(localhost|127\\.0\\.0\\.1)",
+                "--port=8888",
+                "--url=http://localhost:8888",
+            ],
+        )
+
+    assert result.exit_code != 0
+    assert "--demo cannot be combined with --develop-snapshot" in result.output
 
 
 def test_sanitize_status_snapshot_command_writes_redacted_snapshot():

--- a/test/boardwalkd/test_boardwalkd_cli.py
+++ b/test/boardwalkd/test_boardwalkd_cli.py
@@ -1,4 +1,5 @@
 from importlib.metadata import version as lib_version
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from anyio import create_task_group, fail_after, run_process
@@ -41,3 +42,193 @@ async def test_incomplete_serve_command(
             result = await run_process(command=command, check=False)
         assert not scope.cancelled_caught
     assert result.returncode == expected_rc, msg
+
+
+def test_serve_passes_theme_options_to_server_run():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with patch("boardwalkd.cli.run", new_callable=AsyncMock) as run_mock:
+            result = runner.invoke(
+                cli=cli.serve,
+                args=[
+                    "--host-header-pattern=(localhost|127\\.0\\.0\\.1)",
+                    "--port=8888",
+                    "--url=http://localhost:8888",
+                    "--theme-static-path=.",
+                    "--theme-css-url=/theme-static/boardwalkd-custom.css",
+                    "--theme-logo-url=/theme-static/custom-logo.svg",
+                    "--theme-logo-alt=Example",
+                    "--theme-brand-name=Boardwalk",
+                    "--jenkins-job-url=https://ci.example/job/boardwalk/",
+                ],
+            )
+
+    assert result.exit_code == 0
+    kwargs = run_mock.call_args.kwargs
+    assert kwargs["theme_static_path"] == "."
+    assert kwargs["theme_css_url"] == "/theme-static/boardwalkd-custom.css"
+    assert kwargs["theme_logo_url"] == "/theme-static/custom-logo.svg"
+    assert kwargs["theme_logo_alt"] == "Example"
+    assert kwargs["theme_brand_name"] == "Boardwalk"
+    assert kwargs["jenkins_job_url"] == "https://ci.example/job/boardwalk/"
+
+
+def test_serve_passes_develop_snapshot_to_server_run():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open("snapshot.json", "w").write('{"workspaces": []}')
+        with patch("boardwalkd.cli.run", new_callable=AsyncMock) as run_mock:
+            result = runner.invoke(
+                cli=cli.serve,
+                args=[
+                    "--develop",
+                    "--develop-snapshot=snapshot.json",
+                    "--host-header-pattern=(localhost|127\\.0\\.0\\.1)",
+                    "--port=8888",
+                    "--url=http://localhost:8888",
+                ],
+            )
+
+    assert result.exit_code == 0
+    assert run_mock.call_args.kwargs["develop_snapshot_path"] == "snapshot.json"
+
+
+def test_serve_rejects_develop_snapshot_without_develop():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open("snapshot.json", "w").write('{"workspaces": []}')
+        result = runner.invoke(
+            cli=cli.serve,
+            args=[
+                "--develop-snapshot=snapshot.json",
+                "--host-header-pattern=(localhost|127\\.0\\.0\\.1)",
+                "--port=8888",
+                "--url=http://localhost:8888",
+            ],
+        )
+
+    assert result.exit_code != 0
+    assert "--develop-snapshot requires --develop" in result.output
+
+
+def test_sanitize_status_snapshot_command_writes_redacted_snapshot():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open("raw.json", "w").write(
+            """
+            {
+              "workspaces": [{
+                "name": "real_workspace",
+                "semaphores": {"caught": true, "has_mutex": true},
+                "details": {
+                  "current_host": "node-alpha-a",
+                  "ui_group": "alpha",
+                  "worker_hostname": "worker-prod-01",
+                  "worker_username": "operator-a",
+                  "worker_connected": true
+                },
+                "last_seen": "2026-06-03T00:00:00+00:00"
+              }]
+            }
+            """
+        )
+
+        result = runner.invoke(
+            cli=cli.sanitize_status_snapshot,
+            args=["raw.json", "sanitized.json", "--captured-at=2026-06-03T00:00:03+00:00"],
+        )
+        text = open("sanitized.json").read()
+
+    assert result.exit_code == 0
+    assert "snapshot_alpha_001" in text
+    assert "real_workspace" not in text
+    assert "snapshot-host-alpha-001" in text
+    assert "node-alpha-a" not in text
+    assert "worker-prod-01" not in text
+    assert "operator-a" not in text
+
+
+def test_sanitize_status_snapshot_command_can_preserve_identifiers_for_private_replay():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open("raw.json", "w").write(
+            """
+            {
+              "workspaces": [{
+                "name": "real_workspace",
+                "semaphores": {"caught": true, "has_mutex": true},
+                "details": {
+                  "current_host": "node-alpha-a",
+                  "host_pattern": "nodes_alpha",
+                  "worker_hostname": "worker-prod-01",
+                  "worker_username": "operator-a",
+                  "worker_connected": true
+                },
+                "last_seen": "2026-06-03T00:00:00+00:00"
+              }]
+            }
+            """
+        )
+
+        result = runner.invoke(
+            cli=cli.sanitize_status_snapshot,
+            args=[
+                "raw.json",
+                "private-replay.json",
+                "--captured-at=2026-06-03T00:00:03+00:00",
+                "--preserve-identifiers",
+            ],
+        )
+        text = open("private-replay.json").read()
+
+    assert result.exit_code == 0
+    assert "real_workspace" in text
+    assert "node-alpha-a" in text
+    assert "worker-prod-01" in text
+    assert "operator-a" in text
+    assert "alpha" in text
+
+
+def test_sanitize_status_snapshot_command_can_enrich_groups_from_inventory_json():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open("raw.json", "w").write(
+            """
+            {
+              "workspaces": [{
+                "name": "storage_workspace",
+                "semaphores": {"caught": true, "has_mutex": true},
+                "details": {
+                  "host_pattern": "storage_001:!storage_nonprod",
+                  "worker_connected": true
+                },
+                "last_seen": "2026-06-03T00:00:00+00:00"
+              }]
+            }
+            """
+        )
+        open("inventory.json", "w").write(
+            """
+            {
+              "_meta": {"hostvars": {}},
+              "storage_001": {"hosts": ["node-alpha-a"]},
+              "storage_alpha": {"children": ["storage_001"]}
+            }
+            """
+        )
+
+        result = runner.invoke(
+            cli=cli.sanitize_status_snapshot,
+            args=[
+                "raw.json",
+                "private-replay.json",
+                "--captured-at=2026-06-03T00:00:03+00:00",
+                "--preserve-identifiers",
+                "--inventory-json=inventory.json",
+            ],
+        )
+        text = open("private-replay.json").read()
+
+    assert result.exit_code == 0
+    assert "storage_workspace" in text
+    assert '"ui_group": "alpha"' in text

--- a/test/boardwalkd/test_broadcast.py
+++ b/test/boardwalkd/test_broadcast.py
@@ -1,0 +1,64 @@
+from urllib.parse import urlparse
+
+import pytest
+
+import boardwalkd.broadcast as broadcast
+import boardwalkd.server as server
+from boardwalkd.broadcast import handle_auth_login_broadcast
+
+
+@pytest.mark.anyio
+async def test_notify_auth_login_resolves_deployment_user_email_for_slack_mention(monkeypatch):
+    captured = {}
+
+    async def fake_slack_user_mention_for_email(email, slack_bot_token):
+        captured["lookup"] = (email, slack_bot_token)
+        return "<@U123>"
+
+    async def fake_handle_auth_login_broadcast(**kwargs):
+        captured["broadcast"] = kwargs
+
+    monkeypatch.setattr(server, "slack_user_mention_for_email", fake_slack_user_mention_for_email)
+    monkeypatch.setattr(server, "handle_auth_login_broadcast", fake_handle_auth_login_broadcast)
+
+    await server.notify_auth_login(
+        login_url="https://boardwalk.example/api/auth/login?id=abc",
+        auth_context={"deployment_user_email": "lo@example.com"},
+        settings={
+            "slack_webhook_url": "https://hooks.example/general",
+            "slack_error_webhook_url": "https://hooks.example/error",
+            "slack_bot_token": "xoxb-test",
+            "url": urlparse("https://boardwalk.example"),
+        },
+    )
+
+    assert captured["lookup"] == ("lo@example.com", "xoxb-test")
+    assert captured["broadcast"]["slack_user_mention"] == "<@U123>"
+
+
+@pytest.mark.anyio
+async def test_handle_auth_login_broadcast_includes_notifying_block(monkeypatch):
+    captured = {}
+
+    class FakeWebhookClient:
+        def __init__(self, url):
+            captured["url"] = url
+
+        async def send(self, blocks):
+            captured["blocks"] = blocks
+
+    monkeypatch.setattr(broadcast, "AsyncWebhookClient", FakeWebhookClient)
+
+    await handle_auth_login_broadcast(
+        login_url="https://boardwalk.example/api/auth/login?id=abc",
+        auth_context={"deployment_user_email": "lo@example.com"},
+        webhook_url="https://hooks.example/general",
+        error_webhook_url="https://hooks.example/error",
+        server_url="https://boardwalk.example",
+        slack_user_mention="<@U123>",
+    )
+
+    block_text = [block.text.text for block in captured["blocks"] if getattr(block, "text", None)]
+
+    assert captured["url"] == "https://hooks.example/error"
+    assert "*Notifying:* <@U123>" in block_text

--- a/test/boardwalkd/test_dashboard.py
+++ b/test/boardwalkd/test_dashboard.py
@@ -1,4 +1,5 @@
 import hashlib
+from collections import deque
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -56,7 +57,7 @@ def ws(
             worker_username=worker_username,
             workflow="UpgradeWorkflow",
         ),
-        events=events or [],
+        events=deque(events or []),
         last_seen=last_seen,
         semaphores=WorkspaceSemaphores(caught=caught, has_mutex=has_mutex),
     )

--- a/test/boardwalkd/test_dashboard.py
+++ b/test/boardwalkd/test_dashboard.py
@@ -795,7 +795,7 @@ def test_is_workspace_active_uses_supplied_now_for_deterministic_checks(monkeypa
     assert is_workspace_active("inactive", now=now) is False
 
 
-def test_base_template_renders_theme_brand_links_and_scripts_without_github_corner():
+def test_base_template_renders_theme_brand_links_and_scripts():
     loader = Loader(str(Path("src/boardwalkd/templates").resolve()))
     template = loader.load("base.html")
     handler = SimpleNamespace(
@@ -826,6 +826,6 @@ def test_base_template_renders_theme_brand_links_and_scripts_without_github_corn
     assert 'href="/admin"' in html
     assert "View source" not in html
     assert "bw-theme-toggle-icon-light" in html
-    assert "Switch to dark mode" in html
+    assert 'class="bw-theme-dark"' in html
+    assert "Switch to light mode" in html
     assert "/static/boardwalkd.js" in html
-    assert "github-corner" not in html

--- a/test/boardwalkd/test_dashboard.py
+++ b/test/boardwalkd/test_dashboard.py
@@ -23,7 +23,11 @@ from boardwalkd.dashboard import (
     worker_connected,
 )
 from boardwalkd.protocol import WorkspaceDetails, WorkspaceEvent, WorkspaceSemaphores
-from boardwalkd.server import workspace_has_recent_heartbeat
+from boardwalkd.server import (
+    workspace_client_details_event_message,
+    workspace_client_details_event_should_log,
+    workspace_has_recent_heartbeat,
+)
 from boardwalkd.slack_error_advice import SlackErrorAdviceRule
 from boardwalkd.state import WorkspaceState
 
@@ -84,6 +88,41 @@ def test_workspace_details_defaults_new_ui_fields_to_blank_strings():
 def test_workspace_details_still_rejects_unknown_fields():
     with pytest.raises(ValidationError):
         WorkspaceDetails.model_validate({"made_up": "nope"})
+
+
+def test_workspace_client_details_event_logs_initial_client_details():
+    details = WorkspaceDetails(
+        workflow="UpgradeWorkflow",
+        worker_username="operator",
+        worker_hostname="worker-01",
+        host_pattern="nodes",
+        worker_limit="node-alpha-a",
+        worker_command="run",
+    )
+
+    assert workspace_client_details_event_should_log(None, details) is True
+    assert workspace_client_details_event_message(details) == (
+        "Workspace client details:"
+        " Workflow: UpgradeWorkflow,"
+        " Worker: operator@worker-01,"
+        " Host Pattern: nodes,"
+        " Limit Pattern: node-alpha-a,"
+        " Command: run"
+    )
+
+
+def test_workspace_client_details_event_skips_current_host_only_update():
+    old_details = WorkspaceDetails(
+        workflow="UpgradeWorkflow",
+        worker_username="operator",
+        worker_hostname="worker-01",
+        host_pattern="nodes",
+        worker_limit="node-*",
+        worker_command="run",
+    )
+    new_details = old_details.model_copy(update={"current_host": "node-alpha-a", "ui_group": "alpha"})
+
+    assert workspace_client_details_event_should_log(old_details, new_details) is False
 
 
 def test_build_dashboard_groups_counts_and_default_rows_follow_lane_sorting():

--- a/test/boardwalkd/test_dashboard.py
+++ b/test/boardwalkd/test_dashboard.py
@@ -296,41 +296,54 @@ def test_build_dashboard_classifies_rows_into_operational_lanes():
     now = datetime.now(UTC)
     rows = {
         "active_running": ws(last_seen=now, current_host="node-active-running"),
-        "active_caught": ws(caught=True, last_seen=now, current_host="node-active-caught"),
-        "attention_error": ws(
+        "active_previous_error": ws(
+            last_seen=now,
+            has_mutex=False,
+            events=[WorkspaceEvent(severity="error", message="failed earlier", create_time=now - timedelta(minutes=4))],
+        ),
+        "caught_connected": ws(caught=True, last_seen=now, current_host="node-active-caught"),
+        "inactive_error": ws(
             has_mutex=False,
             events=[WorkspaceEvent(severity="error", message="failed", create_time=now - timedelta(minutes=4))],
         ),
-        "attention_caught": ws(caught=True, last_seen=now - timedelta(minutes=2), has_mutex=False),
-        "attention_stale_mutex": ws(last_seen=now - timedelta(hours=25), has_mutex=True),
-        "quiet_done": ws(
+        "inactive_caught": ws(caught=True, last_seen=now - timedelta(minutes=2), has_mutex=False),
+        "inactive_stale_mutex": ws(last_seen=now - timedelta(hours=25), has_mutex=True),
+        "inactive_done": ws(
             has_mutex=False,
             events=[WorkspaceEvent(severity="success", message="done", create_time=now - timedelta(minutes=1))],
         ),
-        "quiet_idle": ws(has_mutex=False),
-        "quiet_stale": ws(last_seen=now - timedelta(hours=25), has_mutex=False),
+        "inactive_idle": ws(has_mutex=False),
+        "inactive_stale": ws(last_seen=now - timedelta(hours=25), has_mutex=False),
     }
 
     dashboard = build_dashboard(rows, DashboardFilters(), now=now)
 
     assert lane_names(dashboard) == {
-        "Active work": ["active_caught", "active_running"],
-        "Needs attention": ["attention_error", "attention_caught", "attention_stale_mutex"],
-        "Quiet work": ["quiet_done", "quiet_idle", "quiet_stale"],
+        "Active workspaces": ["active_running", "active_previous_error"],
+        "Caught workspaces": ["caught_connected"],
+        "Inactive workspaces": [
+            "inactive_error",
+            "inactive_caught",
+            "inactive_stale_mutex",
+            "inactive_stale",
+            "inactive_idle",
+            "inactive_done",
+        ],
     }
     assert [row.name for row in dashboard.rows] == [
-        "active_caught",
         "active_running",
-        "attention_error",
-        "attention_caught",
-        "attention_stale_mutex",
-        "quiet_done",
-        "quiet_idle",
-        "quiet_stale",
+        "active_previous_error",
+        "caught_connected",
+        "inactive_error",
+        "inactive_caught",
+        "inactive_stale_mutex",
+        "inactive_stale",
+        "inactive_idle",
+        "inactive_done",
     ]
 
 
-def test_build_dashboard_reuses_slack_error_advice_for_attention_rows():
+def test_build_dashboard_reuses_slack_error_advice_for_inactive_error_rows():
     now = datetime.now(UTC)
     rule = SlackErrorAdviceRule(
         name="Secret store auth expired",
@@ -354,7 +367,7 @@ def test_build_dashboard_reuses_slack_error_advice_for_attention_rows():
     dashboard = build_dashboard(rows, DashboardFilters(), error_advice_rules=[rule], now=now)
     row = dashboard.rows[0]
 
-    assert lane_names(dashboard) == {"Needs attention": ["auth_expired"]}
+    assert lane_names(dashboard) == {"Inactive workspaces": ["auth_expired"]}
     assert [(advice.name, advice.message) for advice in row.advice] == [
         ("Secret store auth expired", "Abort this CI job and start a fresh Boardwalk job.")
     ]
@@ -370,7 +383,6 @@ def test_build_dashboard_column_sorting_applies_inside_each_lane():
             events=[WorkspaceEvent(severity="info", message="newest", create_time=now)],
         ),
         "aa_jenkins": ws(
-            caught=True,
             last_seen=now,
             current_host="node-a",
             deployment_number="50321",
@@ -390,7 +402,7 @@ def test_build_dashboard_column_sorting_applies_inside_each_lane():
             jenkins_job_url="https://jenkins.example/job/boardwalk/",
             now=now,
         )
-    )["Active work"] == ["aa_jenkins", "mm_local", "zz_deploy"]
+    )["Active workspaces"] == ["aa_jenkins", "mm_local", "zz_deploy"]
     assert lane_names(
         build_dashboard(
             rows,
@@ -398,7 +410,7 @@ def test_build_dashboard_column_sorting_applies_inside_each_lane():
             jenkins_job_url="https://jenkins.example/job/boardwalk/",
             now=now,
         )
-    )["Active work"] == ["aa_jenkins", "mm_local", "zz_deploy"]
+    )["Active workspaces"] == ["aa_jenkins", "mm_local", "zz_deploy"]
     assert lane_names(
         build_dashboard(
             rows,
@@ -406,7 +418,7 @@ def test_build_dashboard_column_sorting_applies_inside_each_lane():
             jenkins_job_url="https://jenkins.example/job/boardwalk/",
             now=now,
         )
-    )["Active work"] == ["zz_deploy", "aa_jenkins", "mm_local"]
+    )["Active workspaces"] == ["zz_deploy", "aa_jenkins", "mm_local"]
     assert lane_names(
         build_dashboard(
             rows,
@@ -414,7 +426,7 @@ def test_build_dashboard_column_sorting_applies_inside_each_lane():
             jenkins_job_url="https://jenkins.example/job/boardwalk/",
             now=now,
         )
-    )["Active work"] == ["mm_local", "zz_deploy", "aa_jenkins"]
+    )["Active workspaces"] == ["aa_jenkins", "mm_local", "zz_deploy"]
     assert lane_names(
         build_dashboard(
             rows,
@@ -422,7 +434,7 @@ def test_build_dashboard_column_sorting_applies_inside_each_lane():
             jenkins_job_url="https://jenkins.example/job/boardwalk/",
             now=now,
         )
-    )["Active work"] == ["zz_deploy", "aa_jenkins", "mm_local"]
+    )["Active workspaces"] == ["zz_deploy", "aa_jenkins", "mm_local"]
 
 
 def test_source_for_workspace_prefers_jenkins_config_then_deployment_url_then_local():
@@ -571,7 +583,8 @@ def test_workspace_partial_renders_lanes_sort_headers_and_advice():
                 )
             ],
         ),
-        "quiet_workspace": ws(
+        "caught_workspace": ws(group="alpha", caught=True, last_seen=now, current_host="node-caught"),
+        "inactive_workspace": ws(
             group="alpha",
             has_mutex=False,
             events=[WorkspaceEvent(severity="success", message="done", create_time=now - timedelta(minutes=1))],
@@ -587,9 +600,9 @@ def test_workspace_partial_renders_lanes_sort_headers_and_advice():
 
     html = render_workspace_partial(dashboard, workspaces)
 
-    assert "Active work" in html
-    assert "Needs attention" in html
-    assert "Quiet work" in html
+    assert "Active workspaces" in html
+    assert "Caught workspaces" in html
+    assert "Inactive workspaces" in html
     assert 'class="bw-sort-label">Workspace</span>' in html
     assert 'class="bw-sort-arrow"' in html
     assert 'aria-label="Workspace sorted by default; sort by workspace"' in html

--- a/test/boardwalkd/test_dashboard.py
+++ b/test/boardwalkd/test_dashboard.py
@@ -9,6 +9,7 @@ import pytest
 from pydantic import ValidationError
 from tornado.template import Loader
 
+import boardwalkd.server as boardwalkd_server
 from boardwalkd.dashboard import (
     DashboardFilters,
     action_url,
@@ -26,10 +27,10 @@ from boardwalkd.protocol import WorkspaceDetails, WorkspaceEvent, WorkspaceSemap
 from boardwalkd.server import (
     workspace_client_details_event_message,
     workspace_client_details_event_should_log,
-    workspace_has_recent_heartbeat,
 )
 from boardwalkd.slack_error_advice import SlackErrorAdviceRule
 from boardwalkd.state import WorkspaceState
+from boardwalkd.utils import is_workspace_active
 
 
 def ws(
@@ -767,8 +768,31 @@ def test_workspace_partial_renders_stale_status_and_filter():
     assert "1 stale" in html
 
 
-def test_workspace_has_recent_heartbeat_treats_missing_last_seen_as_inactive():
-    assert workspace_has_recent_heartbeat(WorkspaceState(last_seen=None), now=datetime.now(UTC)) is False
+def test_is_workspace_active_treats_missing_last_seen_as_inactive(monkeypatch):
+    monkeypatch.setattr(
+        boardwalkd_server,
+        "state",
+        SimpleNamespace(workspaces={"missing_last_seen": WorkspaceState(last_seen=None)}),
+    )
+
+    assert is_workspace_active("missing_last_seen", now=datetime.now(UTC)) is False
+
+
+def test_is_workspace_active_uses_supplied_now_for_deterministic_checks(monkeypatch):
+    now = datetime(2026, 6, 16, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(
+        boardwalkd_server,
+        "state",
+        SimpleNamespace(
+            workspaces={
+                "active": WorkspaceState(last_seen=now - timedelta(seconds=9)),
+                "inactive": WorkspaceState(last_seen=now - timedelta(seconds=11)),
+            }
+        ),
+    )
+
+    assert is_workspace_active("active", now=now) is True
+    assert is_workspace_active("inactive", now=now) is False
 
 
 def test_base_template_renders_theme_brand_links_and_scripts_without_github_corner():

--- a/test/boardwalkd/test_dashboard.py
+++ b/test/boardwalkd/test_dashboard.py
@@ -1,0 +1,754 @@
+import hashlib
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from pydantic import ValidationError
+from tornado.template import Loader
+
+from boardwalkd.dashboard import (
+    DashboardFilters,
+    action_url,
+    build_dashboard,
+    canonical_url,
+    latest_event,
+    partial_url,
+    query_url,
+    sort_url,
+    source_for_workspace,
+    status_for_workspace,
+    worker_connected,
+)
+from boardwalkd.protocol import WorkspaceDetails, WorkspaceEvent, WorkspaceSemaphores
+from boardwalkd.server import workspace_has_recent_heartbeat
+from boardwalkd.slack_error_advice import SlackErrorAdviceRule
+from boardwalkd.state import WorkspaceState
+
+
+def ws(
+    *,
+    group="",
+    current_host="",
+    caught=False,
+    worker_limit="all",
+    deployment_number="",
+    deployment_url="",
+    deployment_user="",
+    worker_hostname="worker-01",
+    worker_username="operator",
+    has_mutex=True,
+    last_seen=None,
+    events=None,
+):
+    return WorkspaceState(
+        details=WorkspaceDetails(
+            current_host=current_host,
+            deployment_number=deployment_number,
+            deployment_url=deployment_url,
+            deployment_user=deployment_user,
+            host_pattern="nodes",
+            ui_group=group,
+            worker_command="run",
+            worker_hostname=worker_hostname,
+            worker_limit=worker_limit,
+            worker_username=worker_username,
+            workflow="UpgradeWorkflow",
+        ),
+        events=events or [],
+        last_seen=last_seen,
+        semaphores=WorkspaceSemaphores(caught=caught, has_mutex=has_mutex),
+    )
+
+
+def lane_names(dashboard):
+    return {lane.label: [row.name for row in lane.rows] for lane in dashboard.lanes}
+
+
+def test_workspace_details_accepts_ui_group_and_current_host():
+    details = WorkspaceDetails(ui_group="alpha", current_host="node-alpha-a")
+
+    assert details.ui_group == "alpha"
+    assert details.current_host == "node-alpha-a"
+
+
+def test_workspace_details_defaults_new_ui_fields_to_blank_strings():
+    details = WorkspaceDetails()
+
+    assert details.ui_group == ""
+    assert details.current_host == ""
+
+
+def test_workspace_details_still_rejects_unknown_fields():
+    with pytest.raises(ValidationError):
+        WorkspaceDetails.model_validate({"made_up": "nope"})
+
+
+def test_build_dashboard_groups_counts_and_default_rows_follow_lane_sorting():
+    rows = {
+        "workspace_beta": ws(group="beta", current_host="node-beta"),
+        "workspace_alpha": ws(group="alpha", current_host="node-alpha"),
+        "workspace_gamma": ws(current_host="node-ungrouped"),
+    }
+
+    dashboard = build_dashboard(rows, DashboardFilters())
+
+    assert [group.label for group in dashboard.groups] == ["All", "alpha", "beta", "Ungrouped"]
+    assert [group.count for group in dashboard.groups] == [3, 1, 1, 1]
+    assert [row.name for row in dashboard.rows] == ["workspace_alpha", "workspace_beta", "workspace_gamma"]
+
+
+def test_build_dashboard_filters_by_selected_group():
+    rows = {
+        "workspace_beta": ws(group="beta", current_host="node-beta"),
+        "workspace_alpha": ws(group="alpha", current_host="node-alpha"),
+    }
+
+    dashboard = build_dashboard(rows, DashboardFilters(group="alpha"))
+
+    assert [row.name for row in dashboard.rows] == ["workspace_alpha"]
+    assert [group.active for group in dashboard.groups] == [False, True, False]
+
+
+def test_build_dashboard_group_counts_follow_current_non_group_filters():
+    now = datetime.now(UTC)
+    rows = {
+        "alpha_caught": ws(group="alpha", caught=True, current_host="node-alpha"),
+        "alpha_running": ws(group="alpha", last_seen=now, current_host="node-alpha-running"),
+        "theta_running": ws(group="theta", last_seen=now, current_host="node-theta"),
+    }
+
+    dashboard = build_dashboard(rows, DashboardFilters(group="theta", status="caught"), now=now)
+
+    assert [(group.label, group.count) for group in dashboard.groups] == [
+        ("All", 1),
+        ("alpha", 1),
+        ("theta", 0),
+    ]
+    assert dashboard.rows == []
+
+
+def test_build_dashboard_filters_search_across_name_host_limit_user_worker_and_build_label():
+    rows = {
+        "workspace_a": ws(group="alpha", current_host="node-alpha-a", worker_limit="node-*"),
+        "workspace_b": ws(group="alpha", deployment_number="12345", deployment_user="operator-a"),
+        "workspace_c": ws(group="net", worker_hostname="worker-special", worker_username="operator-net"),
+    }
+
+    assert [row.name for row in build_dashboard(rows, DashboardFilters(search="alpha-a")).rows] == ["workspace_a"]
+    assert [
+        row.name
+        for row in build_dashboard(
+            rows,
+            DashboardFilters(search="build 12345"),
+            jenkins_job_url="https://jenkins.example/job/boardwalk/",
+        ).rows
+    ] == ["workspace_b"]
+    assert [row.name for row in build_dashboard(rows, DashboardFilters(search="operator-a")).rows] == ["workspace_b"]
+    assert [row.name for row in build_dashboard(rows, DashboardFilters(search="worker-special")).rows] == [
+        "workspace_c"
+    ]
+
+
+def test_build_dashboard_filters_by_status_and_source():
+    now = datetime.now(UTC)
+    deployment_url = "https://ci.example/build/standalone"
+    rows = {
+        "running_workspace": ws(group="alpha", last_seen=now),
+        "jenkins_workspace": ws(group="alpha", deployment_number="12345"),
+        "deployment_workspace": ws(group="alpha", deployment_url=deployment_url),
+    }
+
+    running = build_dashboard(rows, DashboardFilters(status="running"), now=now)
+    jenkins = build_dashboard(
+        rows,
+        DashboardFilters(source="jenkins"),
+        jenkins_job_url="https://jenkins.example/job/boardwalk/",
+        now=now,
+    )
+    deployment = build_dashboard(
+        rows,
+        DashboardFilters(source="deployment"),
+        jenkins_job_url="https://jenkins.example/job/boardwalk/",
+        now=now,
+    )
+
+    assert [row.name for row in running.rows] == ["running_workspace"]
+    assert [row.name for row in jenkins.rows] == ["jenkins_workspace"]
+    assert [row.name for row in deployment.rows] == ["deployment_workspace"]
+
+
+def test_build_dashboard_marks_status_latest_event_worker_connection_and_cleanup_eligibility():
+    now = datetime.now(UTC)
+    rows = {
+        "caught_workspace": ws(
+            group="alpha",
+            caught=True,
+            last_seen=now,
+            events=[
+                WorkspaceEvent(severity="info", message="older", create_time=now - timedelta(seconds=5)),
+                WorkspaceEvent(severity="success", message="newer", create_time=now),
+            ],
+        ),
+    }
+
+    row = build_dashboard(rows, DashboardFilters(), now=now).rows[0]
+
+    assert row.status == "caught"
+    assert row.latest_event == "newer"
+    assert row.worker_connected is True
+    assert row.can_request_remote_cleanup is True
+
+
+def test_status_latest_and_worker_connected_helpers_handle_idle_done_and_error_states():
+    now = datetime.now(UTC)
+    error_ws = ws(events=[WorkspaceEvent(severity="error", message="failed", create_time=now)])
+    done_ws = ws(events=[WorkspaceEvent(severity="success", message="done", create_time=now)])
+    old_ws = ws(last_seen=now - timedelta(seconds=11))
+    stale_ws = ws(last_seen=now - timedelta(days=8))
+
+    assert status_for_workspace(error_ws, now=now) == "error"
+    assert status_for_workspace(done_ws, now=now) == "done"
+    assert status_for_workspace(old_ws, now=now) == "idle"
+    assert status_for_workspace(stale_ws, now=now) == "stale"
+    assert worker_connected(old_ws, now=now) is False
+    assert latest_event(done_ws) == "done"
+
+
+def test_status_for_workspace_uses_latest_terminal_event_after_worker_disconnects():
+    now = datetime.now(UTC)
+    done_after_error = ws(
+        has_mutex=False,
+        last_seen=now - timedelta(minutes=5),
+        events=[
+            WorkspaceEvent(severity="error", message="older failure", create_time=now - timedelta(minutes=10)),
+            WorkspaceEvent(severity="success", message="newer success", create_time=now - timedelta(minutes=1)),
+        ],
+    )
+
+    assert status_for_workspace(done_after_error, now=now) == "done"
+
+
+def test_status_for_workspace_treats_connected_worker_as_running_after_prior_error():
+    now = datetime.now(UTC)
+    running_ws = ws(
+        last_seen=now,
+        events=[
+            WorkspaceEvent(severity="error", message="previous attempt failed", create_time=now - timedelta(minutes=5)),
+            WorkspaceEvent(severity="info", message="Running main TASK job NetworkSetup", create_time=now),
+        ],
+    )
+
+    assert status_for_workspace(running_ws, now=now) == "running"
+
+
+def test_worker_stale_threshold_is_twenty_four_hours():
+    now = datetime.now(UTC)
+    recently_seen = ws(last_seen=now - timedelta(hours=23), has_mutex=False)
+    stale_ws = ws(last_seen=now - timedelta(hours=25), has_mutex=False)
+
+    assert status_for_workspace(recently_seen, now=now) == "idle"
+    assert status_for_workspace(stale_ws, now=now) == "stale"
+
+
+def test_build_dashboard_classifies_rows_into_operational_lanes():
+    now = datetime.now(UTC)
+    rows = {
+        "active_running": ws(last_seen=now, current_host="node-active-running"),
+        "active_caught": ws(caught=True, last_seen=now, current_host="node-active-caught"),
+        "attention_error": ws(
+            has_mutex=False,
+            events=[WorkspaceEvent(severity="error", message="failed", create_time=now - timedelta(minutes=4))],
+        ),
+        "attention_caught": ws(caught=True, last_seen=now - timedelta(minutes=2), has_mutex=False),
+        "attention_stale_mutex": ws(last_seen=now - timedelta(hours=25), has_mutex=True),
+        "quiet_done": ws(
+            has_mutex=False,
+            events=[WorkspaceEvent(severity="success", message="done", create_time=now - timedelta(minutes=1))],
+        ),
+        "quiet_idle": ws(has_mutex=False),
+        "quiet_stale": ws(last_seen=now - timedelta(hours=25), has_mutex=False),
+    }
+
+    dashboard = build_dashboard(rows, DashboardFilters(), now=now)
+
+    assert lane_names(dashboard) == {
+        "Active work": ["active_caught", "active_running"],
+        "Needs attention": ["attention_error", "attention_caught", "attention_stale_mutex"],
+        "Quiet work": ["quiet_done", "quiet_idle", "quiet_stale"],
+    }
+    assert [row.name for row in dashboard.rows] == [
+        "active_caught",
+        "active_running",
+        "attention_error",
+        "attention_caught",
+        "attention_stale_mutex",
+        "quiet_done",
+        "quiet_idle",
+        "quiet_stale",
+    ]
+
+
+def test_build_dashboard_reuses_slack_error_advice_for_attention_rows():
+    now = datetime.now(UTC)
+    rule = SlackErrorAdviceRule(
+        name="Secret store auth expired",
+        patterns=["status: 403", "invalid token"],
+        message="Abort this CI job and start a fresh Boardwalk job.",
+    )
+    rows = {
+        "auth_expired": ws(
+            has_mutex=False,
+            deployment_number="50321",
+            events=[
+                WorkspaceEvent(
+                    severity="error",
+                    message="status: 403; permission denied; invalid token",
+                    create_time=now,
+                )
+            ],
+        )
+    }
+
+    dashboard = build_dashboard(rows, DashboardFilters(), error_advice_rules=[rule], now=now)
+    row = dashboard.rows[0]
+
+    assert lane_names(dashboard) == {"Needs attention": ["auth_expired"]}
+    assert [(advice.name, advice.message) for advice in row.advice] == [
+        ("Secret store auth expired", "Abort this CI job and start a fresh Boardwalk job.")
+    ]
+
+
+def test_build_dashboard_column_sorting_applies_inside_each_lane():
+    now = datetime.now(UTC)
+    rows = {
+        "zz_deploy": ws(
+            last_seen=now,
+            current_host="node-c",
+            deployment_url="https://ci.example/deploy/9",
+            events=[WorkspaceEvent(severity="info", message="newest", create_time=now)],
+        ),
+        "aa_jenkins": ws(
+            caught=True,
+            last_seen=now,
+            current_host="node-a",
+            deployment_number="50321",
+            events=[WorkspaceEvent(severity="info", message="middle", create_time=now - timedelta(minutes=2))],
+        ),
+        "mm_local": ws(
+            last_seen=now,
+            current_host="node-b",
+            events=[WorkspaceEvent(severity="info", message="oldest", create_time=now - timedelta(minutes=5))],
+        ),
+    }
+
+    assert lane_names(
+        build_dashboard(
+            rows,
+            DashboardFilters(sort="workspace"),
+            jenkins_job_url="https://jenkins.example/job/boardwalk/",
+            now=now,
+        )
+    )["Active work"] == ["aa_jenkins", "mm_local", "zz_deploy"]
+    assert lane_names(
+        build_dashboard(
+            rows,
+            DashboardFilters(sort="current_host"),
+            jenkins_job_url="https://jenkins.example/job/boardwalk/",
+            now=now,
+        )
+    )["Active work"] == ["aa_jenkins", "mm_local", "zz_deploy"]
+    assert lane_names(
+        build_dashboard(
+            rows,
+            DashboardFilters(sort="source"),
+            jenkins_job_url="https://jenkins.example/job/boardwalk/",
+            now=now,
+        )
+    )["Active work"] == ["zz_deploy", "aa_jenkins", "mm_local"]
+    assert lane_names(
+        build_dashboard(
+            rows,
+            DashboardFilters(sort="status", direction="desc"),
+            jenkins_job_url="https://jenkins.example/job/boardwalk/",
+            now=now,
+        )
+    )["Active work"] == ["mm_local", "zz_deploy", "aa_jenkins"]
+    assert lane_names(
+        build_dashboard(
+            rows,
+            DashboardFilters(sort="updated", direction="desc"),
+            jenkins_job_url="https://jenkins.example/job/boardwalk/",
+            now=now,
+        )
+    )["Active work"] == ["zz_deploy", "aa_jenkins", "mm_local"]
+
+
+def test_source_for_workspace_prefers_jenkins_config_then_deployment_url_then_local():
+    jenkins_ws = ws(deployment_number="50321", deployment_url="https://ci.example/build/50321")
+    url_ws = ws(deployment_url="https://ci.example/build/standalone")
+    local_ws = ws()
+
+    assert source_for_workspace(jenkins_ws, jenkins_job_url="https://jenkins.example/job/boardwalk/") == (
+        "jenkins",
+        "build 50321",
+        "https://jenkins.example/job/boardwalk/50321/",
+    )
+    assert source_for_workspace(url_ws) == ("deployment", "deployment", "https://ci.example/build/standalone")
+    assert source_for_workspace(local_ws) == ("local", "local", "")
+
+
+def test_query_url_preserves_filters_and_overrides_one_value():
+    url = query_url(
+        "/workspaces",
+        DashboardFilters(group="alpha", search="node", status="running", source="jenkins"),
+        group="beta",
+    )
+    parsed = urlparse(url)
+
+    assert parsed.path == "/workspaces"
+    assert parse_qs(parsed.query) == {
+        "group": ["beta"],
+        "search": ["node"],
+        "status": ["running"],
+        "source": ["jenkins"],
+    }
+
+
+def test_query_url_omits_default_and_empty_filters():
+    assert query_url("/workspaces", DashboardFilters()) == "/workspaces"
+    assert query_url("/workspaces", DashboardFilters(group="alpha"), group="All") == "/workspaces"
+
+
+def test_query_url_preserves_non_default_sort_state():
+    url = query_url(
+        "/workspaces",
+        DashboardFilters(group="alpha", search="node", sort="workspace", direction="desc"),
+        group="beta",
+    )
+    parsed = urlparse(url)
+
+    assert parsed.path == "/workspaces"
+    assert parse_qs(parsed.query) == {
+        "group": ["beta"],
+        "search": ["node"],
+        "sort": ["workspace"],
+        "direction": ["desc"],
+    }
+
+
+def test_index_template_uses_workspaces_url_for_hx_get():
+    loader = Loader(str(Path("src/boardwalkd/templates").resolve()))
+    template = loader.load("index.html")
+    handler = SimpleNamespace(settings={})
+
+    html = template.generate(
+        title="Index",
+        edit=False,
+        workspaces_url="/workspaces?group=alpha&search=node",
+        handler=handler,
+        static_url=lambda value: f"/static/{value}",
+        server_version=lambda: "test",
+        xsrf_form_html=lambda: "",
+        _tt_modules=SimpleNamespace(xsrf_form_html=lambda: ""),
+    ).decode()
+
+    assert 'class="bw-frame"' in html
+    assert 'hx-get="/workspaces?group=alpha&amp;search=node"' in html
+    assert 'hx-trigger="load"' in html
+    assert "every 8s" not in html
+
+
+def render_workspace_partial(dashboard, workspaces=None, edit=False):
+    loader = Loader(str(Path("src/boardwalkd/templates").resolve()))
+    template = loader.load("index_workspace.html")
+    return template.generate(
+        dashboard=dashboard,
+        workspaces=workspaces or {},
+        edit=edit,
+        auth_prompts=[],
+        auth_prompts_by_workspace={},
+        orphan_auth_prompts=[],
+        jenkins_job_url="https://ci.example/job/boardwalk/",
+        action_url=action_url,
+        canonical_url=canonical_url,
+        partial_url=partial_url,
+        query_url=query_url,
+        sort_url=sort_url,
+        secondsdelta=lambda value: 0,
+        sha256=lambda value: hashlib.sha256(value.encode()).hexdigest(),
+        sort_events_by_date=lambda events: events,
+        squeeze=lambda value: value,
+        xsrf_form_html=lambda: "",
+    ).decode()
+
+
+def test_workspace_partial_renders_refreshed_rows_without_progress():
+    workspaces = {
+        "workspace_alpha": ws(
+            group="alpha",
+            current_host="node-alpha-a",
+            deployment_number="50321",
+            events=[WorkspaceEvent(severity="info", message="Locking remote host")],
+        )
+    }
+    dashboard = build_dashboard(
+        workspaces,
+        DashboardFilters(group="alpha"),
+        jenkins_job_url="https://ci.example/job/boardwalk/",
+    )
+
+    html = render_workspace_partial(dashboard, workspaces)
+
+    assert 'class="bw-row status-idle"' in html
+    assert "workspace_alpha" in html
+    assert "node-alpha-a" in html
+    assert "Locking remote host" in html
+    assert "https://ci.example/job/boardwalk/50321/" in html
+    assert "progress" not in html.lower()
+    assert "50%" not in html
+
+
+def test_workspace_partial_renders_lanes_sort_headers_and_advice():
+    now = datetime.now(UTC)
+    rule = SlackErrorAdviceRule(
+        name="Secret store auth expired",
+        patterns=["status: 403", "invalid token"],
+        message="Abort this CI job and start a fresh Boardwalk job.",
+    )
+    workspaces = {
+        "active_workspace": ws(group="alpha", last_seen=now, current_host="node-active"),
+        "auth_expired": ws(
+            group="alpha",
+            has_mutex=False,
+            deployment_number="50321",
+            events=[
+                WorkspaceEvent(
+                    severity="error",
+                    message="status: 403 invalid token",
+                    create_time=now - timedelta(minutes=5),
+                )
+            ],
+        ),
+        "quiet_workspace": ws(
+            group="alpha",
+            has_mutex=False,
+            events=[WorkspaceEvent(severity="success", message="done", create_time=now - timedelta(minutes=1))],
+        ),
+    }
+    dashboard = build_dashboard(
+        workspaces,
+        DashboardFilters(group="alpha"),
+        jenkins_job_url="https://ci.example/job/boardwalk/",
+        error_advice_rules=[rule],
+        now=now,
+    )
+
+    html = render_workspace_partial(dashboard, workspaces)
+
+    assert "Active work" in html
+    assert "Needs attention" in html
+    assert "Quiet work" in html
+    assert 'class="bw-sort-label">Workspace</span>' in html
+    assert 'class="bw-sort-arrow"' in html
+    assert 'aria-label="Workspace sorted by default; sort by workspace"' in html
+    assert "sort=workspace" in html
+    assert "sort=current_host" in html
+    assert "sort=source" in html
+    assert "sort=status" in html
+    assert "sort=updated" in html
+    assert "Secret store auth expired" in html
+    assert "Abort this CI job and start a fresh Boardwalk job." in html
+
+
+def test_workspace_partial_places_expand_control_in_workspace_cell_with_stable_key():
+    workspaces = {
+        "workspace_alpha": ws(
+            group="alpha",
+            current_host="node-alpha-a",
+        )
+    }
+    dashboard = build_dashboard(workspaces, DashboardFilters(group="alpha"))
+
+    html = render_workspace_partial(dashboard, workspaces)
+    workspace_key = hashlib.sha256(b"workspace_alpha").hexdigest()
+    row_start = html.index("data-workspace-row")
+    name_start = html.index('class="bw-workspace-name"')
+    actions_start = html.index('class="bw-actions-cell"')
+
+    assert f'data-workspace-key="{workspace_key}"' in html
+    assert f'class="bw-expand" data-row-toggle data-workspace-key="{workspace_key}"' in html
+    assert 'class="bw-row-details status-idle"' in html
+    assert f'data-workspace-key="{workspace_key}" hidden>' in html
+    assert row_start < html.index('class="bw-expand" data-row-toggle') < name_start < actions_start
+
+
+def test_workspace_partial_catch_release_actions_refresh_current_frame_without_navigation():
+    workspaces = {
+        "workspace_alpha": ws(
+            group="alpha",
+            current_host="node-alpha-a",
+            caught=False,
+            last_seen=datetime.now(UTC),
+        )
+    }
+    dashboard = build_dashboard(workspaces, DashboardFilters(group="alpha", status="running"))
+
+    html = render_workspace_partial(dashboard, workspaces, edit=True)
+
+    assert 'hx-post="/workspace/workspace_alpha/semaphores/caught?group=alpha&amp;status=running&amp;edit=1"' in html
+    assert 'hx-target="closest .bw-frame"' in html
+    assert 'hx-push-url="false"' in html
+
+    workspaces["workspace_alpha"].semaphores.caught = True
+    dashboard = build_dashboard(workspaces, DashboardFilters(group="alpha", status="caught"))
+
+    html = render_workspace_partial(dashboard, workspaces, edit=True)
+
+    assert 'hx-delete="/workspace/workspace_alpha/semaphores/caught?group=alpha&amp;status=caught&amp;edit=1"' in html
+    assert 'hx-target="closest .bw-frame"' in html
+    assert 'hx-push-url="false"' in html
+
+
+def test_workspace_partial_polls_current_partial_url_without_pushing_history():
+    workspaces = {
+        "workspace_alpha": ws(group="alpha", current_host="node-alpha-a"),
+    }
+    dashboard = build_dashboard(workspaces, DashboardFilters(group="alpha", status="running"))
+
+    html = render_workspace_partial(dashboard, workspaces, edit=True)
+
+    assert 'hx-get="/workspaces?group=alpha&amp;status=running&amp;edit=1"' in html
+    assert 'hx-trigger="every 8s"' in html
+    assert "push_url=1" not in html.split('hx-trigger="every 8s"', 1)[0]
+
+
+def test_workspace_partial_uses_canonical_urls_for_htmx_history():
+    dashboard = build_dashboard({}, DashboardFilters(group="alpha", search="node", status="running", source="jenkins"))
+
+    html = render_workspace_partial(dashboard, edit=True)
+
+    assert 'href="/?search=node&amp;status=running&amp;source=jenkins&amp;edit=1"' in html
+    assert 'hx-get="/workspaces?search=node&amp;status=running&amp;source=jenkins&amp;edit=1&amp;push_url=1"' in html
+    assert 'href="/?group=alpha&amp;search=node&amp;status=running&amp;source=jenkins"' in html
+    assert 'action="/"' in html
+    assert 'hx-get="/workspaces"' in html
+    assert 'hx-vals=\'{"push_url":"1"}\'' in html
+
+
+def test_workspace_partial_renders_remote_cleanup_actions_for_caught_active_workspace():
+    workspaces = {
+        "workspace_alpha": ws(
+            group="alpha",
+            current_host="node-alpha-a",
+            caught=True,
+            last_seen=datetime.now(UTC),
+        )
+    }
+    dashboard = build_dashboard(workspaces, DashboardFilters(group="alpha"))
+
+    html = render_workspace_partial(dashboard, workspaces)
+
+    assert "Clear remote Boardwalk fact file" in html
+    assert "Clear remote host mutex" in html
+
+
+def test_workspace_partial_renders_extra_events_inline_without_more_events_page_link():
+    now = datetime.now(UTC)
+    workspaces = {
+        "workspace_alpha": ws(
+            group="alpha",
+            current_host="node-alpha-a",
+            events=[
+                WorkspaceEvent(severity="info", message=f"event {index}", create_time=now - timedelta(seconds=index))
+                for index in range(8)
+            ],
+        )
+    }
+    dashboard = build_dashboard(workspaces, DashboardFilters(group="alpha"), now=now)
+
+    html = render_workspace_partial(dashboard, workspaces)
+
+    assert "Show 2 more" in html
+    assert 'href="/workspace/workspace_alpha/events"' not in html
+    assert "data-event-extra" in html
+
+
+def test_workspace_partial_preserves_filter_state_in_edit_link():
+    dashboard = build_dashboard({}, DashboardFilters(group="alpha", search="node", status="running", source="jenkins"))
+
+    html = render_workspace_partial(dashboard)
+
+    assert 'href="/?group=alpha&amp;search=node&amp;status=running&amp;source=jenkins&amp;edit=1"' in html
+
+
+def test_workspace_partial_renders_edit_delete_actions_with_existing_guards():
+    old = datetime.now(UTC) - timedelta(days=8)
+    workspaces = {
+        "deletable": ws(group="alpha", has_mutex=False, last_seen=old),
+        "mutexed": ws(group="alpha", has_mutex=True, last_seen=old),
+    }
+    dashboard = build_dashboard(workspaces, DashboardFilters(group="alpha"))
+
+    html = render_workspace_partial(dashboard, workspaces, edit=True)
+
+    assert 'hx-post="/workspace/deletable/delete?group=alpha&amp;edit=1"' in html
+    assert 'hx-target="closest .bw-frame"' in html
+    assert 'hx-delete="/workspace/mutexed/semaphores/has_mutex?group=alpha&amp;edit=1"' in html
+    assert "Delete workspace" in html
+    assert "Clear workspace mutex" in html
+
+
+def test_workspace_partial_renders_stale_status_and_filter():
+    old = datetime.now(UTC) - timedelta(days=8)
+    workspaces = {
+        "stale_workspace": ws(group="alpha", last_seen=old),
+    }
+    dashboard = build_dashboard(workspaces, DashboardFilters(status="stale"), now=datetime.now(UTC))
+
+    html = render_workspace_partial(dashboard, workspaces)
+
+    assert 'class="bw-row status-stale"' in html
+    assert '<option value="stale" selected>Stale</option>' in html
+    assert "1 stale" in html
+
+
+def test_workspace_has_recent_heartbeat_treats_missing_last_seen_as_inactive():
+    assert workspace_has_recent_heartbeat(WorkspaceState(last_seen=None), now=datetime.now(UTC)) is False
+
+
+def test_base_template_renders_theme_brand_links_and_scripts_without_github_corner():
+    loader = Loader(str(Path("src/boardwalkd/templates").resolve()))
+    template = loader.load("base.html")
+    handler = SimpleNamespace(
+        settings={
+            "theme_css_url": "/theme-static/boardwalkd-custom.css",
+            "theme_logo_url": "/theme-static/custom-logo.svg",
+            "theme_logo_alt": "Example",
+            "theme_brand_name": "Boardwalk Ops",
+        }
+    )
+
+    html = template.generate(
+        title="Index",
+        handler=handler,
+        static_url=lambda value: f"/static/{value}",
+        server_version=lambda: "test",
+        xsrf_form_html=lambda: "",
+        _tt_modules=SimpleNamespace(xsrf_form_html=lambda: ""),
+    ).decode()
+
+    assert html.index("/static/boardwalkd.css") < html.index("/theme-static/boardwalkd-custom.css")
+    assert 'rel="icon"' in html
+    assert 'href="/static/favicon.svg"' in html
+    assert 'src="/theme-static/custom-logo.svg"' in html
+    assert 'alt="Example"' in html
+    assert "Boardwalk Ops" in html
+    assert 'href="/"' in html
+    assert 'href="/admin"' in html
+    assert "View source" not in html
+    assert "bw-theme-toggle-icon-light" in html
+    assert "Switch to dark mode" in html
+    assert "/static/boardwalkd.js" in html
+    assert "github-corner" not in html

--- a/test/boardwalkd/test_demo.py
+++ b/test/boardwalkd/test_demo.py
@@ -1,0 +1,89 @@
+from boardwalkd.dashboard import DashboardFilters, build_dashboard
+from boardwalkd.demo import seed_development_workspaces
+from boardwalkd.state import State, WorkspaceState
+
+
+def test_seed_development_workspaces_adds_clickable_mock_data_to_empty_state():
+    state = State()
+
+    seeded = seed_development_workspaces(state)
+    dashboard = build_dashboard(state.workspaces, DashboardFilters(group="alpha", status="caught"))
+
+    assert seeded is True
+    assert len(state.workspaces) >= 10
+    assert {ws.details.ui_group or "Ungrouped" for ws in state.workspaces.values()} >= {
+        "alpha",
+        "beta",
+        "delta",
+        "gamma",
+        "omega",
+        "theta",
+        "Ungrouped",
+    }
+    assert any(ws.details.current_host for ws in state.workspaces.values())
+    assert any(ws.semaphores.caught for ws in state.workspaces.values())
+    assert any(ws.details.deployment_number for ws in state.workspaces.values())
+    assert any(not ws.details.deployment_number for ws in state.workspaces.values())
+    assert any(len(name) > 40 for name in state.workspaces)
+    assert any(len(ws.details.current_host) > 40 for ws in state.workspaces.values())
+    assert any(row.can_request_remote_cleanup for row in dashboard.rows)
+    assert any(row.status == "stale" for row in build_dashboard(state.workspaces, DashboardFilters()).rows)
+
+
+def test_seed_development_workspaces_uses_generic_fictional_host_patterns():
+    state = State()
+
+    seed_development_workspaces(state)
+    details = {name: workspace.details for name, workspace in state.workspaces.items()}
+
+    assert details["nodes_alpha_group_upgrade"].host_pattern == "nodes_alpha"
+    assert details["nodes_alpha_group_upgrade"].current_host == "node-alpha-a"
+    assert details["nodes_alpha_group_upgrade"].ui_group == "alpha"
+
+    assert details["nodes_beta_group_upgrade"].host_pattern == "nodes_beta"
+    assert details["nodes_beta_group_upgrade"].current_host == "node-beta-a"
+    assert details["nodes_beta_group_upgrade"].ui_group == "beta"
+
+    assert details["nodes_multi_group_beta_current"].host_pattern == "nodes_alpha:nodes_beta:nodes_gamma"
+    assert details["nodes_multi_group_beta_current"].current_host == "node-beta-a"
+    assert details["nodes_multi_group_beta_current"].ui_group == "beta"
+
+    assert details["storage_multi_group_alpha_current"].host_pattern == "storage_alpha:storage_beta:storage_gamma"
+    assert details["storage_multi_group_alpha_current"].current_host == "storage-alpha-a"
+    assert details["storage_multi_group_alpha_current"].ui_group == "alpha"
+    assert details["stale_deletable_workspace"].host_pattern == "nodes_omega"
+    assert details["stale_deletable_workspace"].current_host == "node-omega-b"
+    assert state.workspaces["stale_deletable_workspace"].semaphores.has_mutex is False
+    assert details["stale_mutexed_workspace"].host_pattern == "nodes_theta"
+    assert details["stale_mutexed_workspace"].current_host == "node-theta-b"
+
+
+def test_seed_development_workspaces_sorts_demo_rows_into_group_tabs():
+    state = State()
+
+    seed_development_workspaces(state)
+    dashboard = build_dashboard(state.workspaces, DashboardFilters())
+
+    assert [group.label for group in dashboard.groups] == [
+        "All",
+        "alpha",
+        "beta",
+        "delta",
+        "gamma",
+        "omega",
+        "theta",
+        "Ungrouped",
+    ]
+    for group in ["alpha", "beta", "delta", "gamma", "omega", "theta"]:
+        group_dashboard = build_dashboard(state.workspaces, DashboardFilters(group=group))
+        assert group_dashboard.rows
+        assert {row.group for row in group_dashboard.rows} == {group}
+
+
+def test_seed_development_workspaces_does_not_overwrite_existing_state():
+    state = State(workspaces={"real": WorkspaceState()})
+
+    seeded = seed_development_workspaces(state)
+
+    assert seeded is False
+    assert list(state.workspaces) == ["real"]

--- a/test/boardwalkd/test_demo.py
+++ b/test/boardwalkd/test_demo.py
@@ -80,6 +80,16 @@ def test_seed_development_workspaces_sorts_demo_rows_into_group_tabs():
         assert {row.group for row in group_dashboard.rows} == {group}
 
 
+def test_seed_development_workspaces_keeps_most_demo_rows_deletable_in_edit_mode():
+    state = State()
+
+    seed_development_workspaces(state)
+
+    assert state.workspaces["nodes_alpha_group_upgrade"].semaphores.has_mutex is False
+    assert state.workspaces["very_very_long_workspace_name_for_fit_testing_and_demo"].semaphores.has_mutex is False
+    assert state.workspaces["stale_mutexed_workspace"].semaphores.has_mutex is True
+
+
 def test_seed_development_workspaces_does_not_overwrite_existing_state():
     state = State(workspaces={"real": WorkspaceState()})
 

--- a/test/boardwalkd/test_snapshot.py
+++ b/test/boardwalkd/test_snapshot.py
@@ -1,0 +1,309 @@
+import json
+import re
+from datetime import UTC, datetime, timedelta
+
+import boardwalkd.server as server
+from boardwalkd.dashboard import DashboardFilters, build_dashboard
+from boardwalkd.snapshot import load_inventory_context, sanitize_status_snapshot, seed_snapshot_workspaces
+from boardwalkd.state import State, WorkspaceState
+
+
+def raw_status_snapshot(now: datetime):
+    return {
+        "workspaces": [
+            {
+                "name": "active_workspace_name",
+                "semaphores": {
+                    "caught": True,
+                    "clear_remote_mutex_requested": False,
+                    "clear_remote_state_requested": False,
+                    "has_mutex": True,
+                },
+                "details": {
+                    "current_host": "node-alpha-a",
+                    "deployment_number": "50321",
+                    "deployment_url": "https://jenkins.example/job/boardwalk/50321/",
+                    "deployment_user": "operator1",
+                    "deployment_user_email": "operator1@example.com",
+                    "host_pattern": "nodes_alpha:nodes_beta",
+                    "ui_group": "alpha",
+                    "workflow": "NodeUpgrade",
+                    "worker_command": "run",
+                    "worker_hostname": "worker-prod-01",
+                    "worker_limit": "node-alpha-a",
+                    "worker_username": "operator1",
+                    "worker": "operator1@worker-prod-01",
+                    "worker_connected": True,
+                },
+                "last_seen": (now - timedelta(seconds=3)).isoformat(),
+            },
+            {
+                "name": "old_workspace_name",
+                "semaphores": {"caught": False, "has_mutex": False},
+                "details": {
+                    "current_host": "",
+                    "host_pattern": "nodes_theta",
+                    "ui_group": "",
+                    "workflow": "StaleCleanup",
+                    "worker_hostname": "worker-prod-02",
+                    "worker_username": "operator2",
+                    "worker_connected": False,
+                },
+                "last_seen": (now - timedelta(days=9)).isoformat(),
+            },
+            {
+                "name": "multi_group_workspace_name",
+                "semaphores": {"caught": False, "has_mutex": True},
+                "details": {
+                    "current_host": "",
+                    "host_pattern": "nodes_alpha:nodes_beta",
+                    "workflow": "MultiGroupCanary",
+                    "worker_hostname": "worker-prod-03",
+                    "worker_username": "operator2",
+                    "worker_connected": True,
+                },
+                "last_seen": (now - timedelta(seconds=2)).isoformat(),
+            },
+        ]
+    }
+
+
+def test_sanitize_status_snapshot_redacts_sensitive_identifiers_but_preserves_operational_shape():
+    now = datetime(2026, 6, 3, tzinfo=UTC)
+
+    sanitized = sanitize_status_snapshot(raw_status_snapshot(now), now=now)
+
+    assert sanitized["snapshot_format"] == "boardwalkd-status-snapshot-v1"
+    assert sanitized["captured_at"] == "2026-06-03T00:00:00+00:00"
+    assert [workspace["name"] for workspace in sanitized["workspaces"]] == [
+        "snapshot_alpha_001",
+        "snapshot_theta_002",
+        "snapshot_multi_group_003",
+    ]
+    assert sanitized["workspaces"][0]["details"]["ui_group"] == "alpha"
+    assert sanitized["workspaces"][0]["details"]["current_host"] == "snapshot-host-alpha-001"
+    assert sanitized["workspaces"][0]["details"]["host_pattern"] == "pattern-alpha-001:pattern-beta-001"
+    assert sanitized["workspaces"][0]["details"]["deployment_number"] == "snapshot-build-001"
+    assert sanitized["workspaces"][0]["details"]["deployment_url"] == "https://snapshot.invalid/deployment/001/"
+    assert sanitized["workspaces"][0]["details"]["worker_limit"] == "snapshot-host-alpha-001"
+    assert sanitized["workspaces"][0]["worker_connected"] is True
+    assert sanitized["workspaces"][1]["details"]["ui_group"] == "theta"
+    assert sanitized["workspaces"][1]["last_seen_age_seconds"] == 9 * 24 * 60 * 60
+    assert sanitized["workspaces"][2]["details"]["ui_group"] == "Multi-group"
+
+    text = repr(sanitized)
+    assert "active_workspace_name" not in text
+    assert "old_workspace_name" not in text
+    assert "multi_group_workspace_name" not in text
+    assert "node-alpha-a" not in text
+    assert "nodes_alpha" not in text
+    assert "50321" not in text
+    assert "worker-prod-01" not in text
+    assert "operator1" not in text
+    assert all(re.fullmatch(r"\w+", workspace["name"]) for workspace in sanitized["workspaces"])
+
+
+def test_sanitize_status_snapshot_can_preserve_identifiers_for_private_local_replay():
+    now = datetime(2026, 6, 3, tzinfo=UTC)
+
+    snapshot = sanitize_status_snapshot(raw_status_snapshot(now), now=now, preserve_identifiers=True)
+
+    assert [workspace["name"] for workspace in snapshot["workspaces"]] == [
+        "active_workspace_name",
+        "old_workspace_name",
+        "multi_group_workspace_name",
+    ]
+    assert snapshot["workspaces"][0]["details"]["worker_hostname"] == "worker-prod-01"
+    assert snapshot["workspaces"][0]["details"]["worker_username"] == "operator1"
+    assert snapshot["workspaces"][0]["details"]["deployment_user"] == "operator1"
+    assert snapshot["workspaces"][1]["details"]["ui_group"] == "theta"
+    assert snapshot["workspaces"][2]["details"]["ui_group"] == "Multi-group"
+    assert "worker_connected" not in snapshot["workspaces"][0]["details"]
+
+
+def test_sanitize_status_snapshot_does_not_guess_group_from_numeric_storage_pattern():
+    now = datetime(2026, 6, 3, tzinfo=UTC)
+    snapshot = sanitize_status_snapshot(
+        {
+            "workspaces": [
+                {
+                    "name": "storage_workspace",
+                    "semaphores": {"caught": False, "has_mutex": True},
+                    "details": {
+                        "host_pattern": "storage_001:!storage_nonprod",
+                        "worker_hostname": "worker-prod-01",
+                        "worker_username": "operator1",
+                        "worker_connected": True,
+                    },
+                    "last_seen": now.isoformat(),
+                }
+            ]
+        },
+        now=now,
+        preserve_identifiers=True,
+    )
+
+    workspace = snapshot["workspaces"][0]
+    assert workspace["name"] == "storage_workspace"
+    assert workspace["details"]["host_pattern"] == "storage_001:!storage_nonprod"
+    assert workspace["details"]["ui_group"] == ""
+
+
+def test_sanitize_status_snapshot_can_derive_group_from_inventory_group_ancestry():
+    now = datetime(2026, 6, 3, tzinfo=UTC)
+    inventory = {
+        "_meta": {"hostvars": {}},
+        "storage_001": {"hosts": ["node-alpha-a"]},
+        "storage_002": {"hosts": ["node-beta-a"]},
+        "storage_alpha": {"children": ["storage_001"]},
+        "storage_beta": {"children": ["storage_002"]},
+    }
+
+    snapshot = sanitize_status_snapshot(
+        {
+            "workspaces": [
+                {
+                    "name": "alpha-storage",
+                    "semaphores": {"caught": False, "has_mutex": True},
+                    "details": {
+                        "host_pattern": "storage_001:!storage_nonprod",
+                        "worker_connected": True,
+                    },
+                    "last_seen": now.isoformat(),
+                },
+                {
+                    "name": "beta-storage",
+                    "semaphores": {"caught": False, "has_mutex": True},
+                    "details": {
+                        "host_pattern": "storage_002:!storage_nonprod",
+                        "worker_connected": True,
+                    },
+                    "last_seen": now.isoformat(),
+                },
+            ]
+        },
+        now=now,
+        preserve_identifiers=True,
+        inventory=inventory,
+    )
+
+    assert snapshot["workspaces"][0]["details"]["ui_group"] == "alpha"
+    assert snapshot["workspaces"][1]["details"]["ui_group"] == "beta"
+
+
+def test_sanitize_status_snapshot_marks_multi_group_when_inventory_ancestry_has_multiple_groups():
+    now = datetime(2026, 6, 3, tzinfo=UTC)
+    inventory = {
+        "_meta": {"hostvars": {}},
+        "storage_001": {"hosts": ["node-alpha-a"]},
+        "storage_002": {"hosts": ["node-beta-a"]},
+        "storage_alpha": {"children": ["storage_001"]},
+        "storage_beta": {"children": ["storage_002"]},
+    }
+
+    snapshot = sanitize_status_snapshot(
+        {
+            "workspaces": [
+                {
+                    "name": "multi-storage",
+                    "semaphores": {"caught": False, "has_mutex": True},
+                    "details": {
+                        "host_pattern": "storage_001:storage_002:!storage_nonprod",
+                        "worker_connected": True,
+                    },
+                    "last_seen": now.isoformat(),
+                }
+            ]
+        },
+        now=now,
+        preserve_identifiers=True,
+        inventory=inventory,
+    )
+
+    assert snapshot["workspaces"][0]["details"]["ui_group"] == "Multi-group"
+
+
+def test_load_inventory_context_reads_inventory_json(tmp_path):
+    path = tmp_path / "inventory.json"
+    path.write_text(json.dumps({"_meta": {"hostvars": {}}, "storage_alpha": {"children": []}}))
+
+    assert load_inventory_context(path)["storage_alpha"]["children"] == []
+
+
+def test_seed_snapshot_workspaces_replays_sanitized_status_into_local_state(tmp_path):
+    captured_at = datetime(2026, 6, 3, tzinfo=UTC)
+    replay_now = datetime(2026, 6, 4, tzinfo=UTC)
+    sanitized = sanitize_status_snapshot(raw_status_snapshot(captured_at), now=captured_at)
+    path = tmp_path / "snapshot.json"
+    path.write_text(json.dumps(sanitized))
+    state = State()
+
+    seeded = seed_snapshot_workspaces(state, path, now=replay_now)
+    dashboard = build_dashboard(state.workspaces, DashboardFilters(), now=replay_now)
+
+    assert seeded is True
+    assert set(state.workspaces) == {"snapshot_alpha_001", "snapshot_theta_002", "snapshot_multi_group_003"}
+    assert state.workspaces["snapshot_alpha_001"].details.current_host == "snapshot-host-alpha-001"
+    assert state.workspaces["snapshot_alpha_001"].semaphores.caught is True
+    assert state.workspaces["snapshot_alpha_001"].last_seen > replay_now
+    assert state.workspaces["snapshot_theta_002"].last_seen == replay_now - timedelta(days=9)
+    assert [(group.label, group.count) for group in dashboard.groups] == [
+        ("All", 3),
+        ("alpha", 1),
+        ("Multi-group", 1),
+        ("theta", 1),
+    ]
+    assert [row.status for row in dashboard.rows] == ["caught", "running", "stale"]
+    assert all("Sanitized production status snapshot" in row.latest_event for row in dashboard.rows)
+
+
+def test_seed_snapshot_workspaces_sanitizes_raw_status_before_persisting(tmp_path):
+    now = datetime(2026, 6, 3, tzinfo=UTC)
+    path = tmp_path / "raw.json"
+    path.write_text(json.dumps(raw_status_snapshot(now)))
+    state = State()
+
+    seeded = seed_snapshot_workspaces(state, path, now=now)
+
+    assert seeded is True
+    assert "active_workspace_name" not in state.workspaces
+    assert state.workspaces["snapshot_alpha_001"].details.worker_hostname == "snapshot-worker-alpha-001"
+    assert state.workspaces["snapshot_theta_002"].details.ui_group == "theta"
+
+
+def test_seed_snapshot_workspaces_does_not_overwrite_existing_state(tmp_path):
+    path = tmp_path / "snapshot.json"
+    path.write_text('{"workspaces": []}')
+    state = State(workspaces={"existing": WorkspaceState()})
+
+    seeded = seed_snapshot_workspaces(state, path)
+
+    assert seeded is False
+    assert list(state.workspaces) == ["existing"]
+
+
+def test_development_server_uses_snapshot_seed_instead_of_synthetic_demo_seed(tmp_path, monkeypatch):
+    now = datetime(2026, 6, 3, tzinfo=UTC)
+    path = tmp_path / "snapshot.json"
+    path.write_text(json.dumps(sanitize_status_snapshot(raw_status_snapshot(now), now=now)))
+    state = State()
+    monkeypatch.setattr(server, "state", state)
+
+    server.make_app(
+        auth_expire_days=14,
+        auth_login_slack_notify=False,
+        auth_method="anonymous",
+        develop=True,
+        develop_snapshot_path=str(path),
+        host_header_pattern=re.compile(r"localhost(:[0-9]+)?"),
+        owner="anonymous@example.com",
+        slack_bot_token=None,
+        slack_error_advice_rules=[],
+        slack_error_webhook_url=None,
+        slack_webhook_url=None,
+        url="http://localhost:8888",
+        workspace_status_json=True,
+    )
+
+    assert set(state.workspaces) == {"snapshot_alpha_001", "snapshot_theta_002", "snapshot_multi_group_003"}
+    assert "nodes_alpha_group_upgrade" not in state.workspaces

--- a/test/boardwalkd/test_snapshot.py
+++ b/test/boardwalkd/test_snapshot.py
@@ -256,7 +256,11 @@ def test_seed_snapshot_workspaces_replays_sanitized_status_into_local_state(tmp_
         ("Multi-group", 1),
         ("theta", 1),
     ]
-    assert [row.status for row in dashboard.rows] == ["caught", "running", "stale"]
+    assert [(lane.label, [row.status for row in lane.rows]) for lane in dashboard.lanes] == [
+        ("Active workspaces", ["running"]),
+        ("Caught workspaces", ["caught"]),
+        ("Inactive workspaces", ["stale"]),
+    ]
     assert all("Sanitized production status snapshot" in row.latest_event for row in dashboard.rows)
 
 

--- a/test/boardwalkd/test_snapshot.py
+++ b/test/boardwalkd/test_snapshot.py
@@ -226,8 +226,10 @@ def test_sanitize_status_snapshot_marks_multi_group_when_inventory_ancestry_has_
 def test_load_inventory_context_reads_inventory_json(tmp_path):
     path = tmp_path / "inventory.json"
     path.write_text(json.dumps({"_meta": {"hostvars": {}}, "storage_alpha": {"children": []}}))
+    inventory = load_inventory_context(path)
 
-    assert load_inventory_context(path)["storage_alpha"]["children"] == []
+    assert inventory is not None
+    assert inventory["storage_alpha"]["children"] == []
 
 
 def test_seed_snapshot_workspaces_replays_sanitized_status_into_local_state(tmp_path):
@@ -245,6 +247,7 @@ def test_seed_snapshot_workspaces_replays_sanitized_status_into_local_state(tmp_
     assert set(state.workspaces) == {"snapshot_alpha_001", "snapshot_theta_002", "snapshot_multi_group_003"}
     assert state.workspaces["snapshot_alpha_001"].details.current_host == "snapshot-host-alpha-001"
     assert state.workspaces["snapshot_alpha_001"].semaphores.caught is True
+    assert state.workspaces["snapshot_alpha_001"].last_seen is not None
     assert state.workspaces["snapshot_alpha_001"].last_seen > replay_now
     assert state.workspaces["snapshot_theta_002"].last_seen == replay_now - timedelta(days=9)
     assert [(group.label, group.count) for group in dashboard.groups] == [
@@ -282,6 +285,51 @@ def test_seed_snapshot_workspaces_does_not_overwrite_existing_state(tmp_path):
     assert list(state.workspaces) == ["existing"]
 
 
+def test_development_server_does_not_seed_demo_without_demo_flag(monkeypatch):
+    state = State()
+    monkeypatch.setattr(server, "state", state)
+
+    server.make_app(
+        auth_expire_days=14,
+        auth_login_slack_notify=False,
+        auth_method="anonymous",
+        develop=True,
+        host_header_pattern=re.compile(r"localhost(:[0-9]+)?"),
+        owner="anonymous@example.com",
+        slack_bot_token=None,
+        slack_error_advice_rules=[],
+        slack_error_webhook_url="",
+        slack_webhook_url="",
+        url="http://localhost:8888",
+        workspace_status_json=True,
+    )
+
+    assert state.workspaces == {}
+
+
+def test_server_uses_demo_seed_when_requested(monkeypatch):
+    state = State()
+    monkeypatch.setattr(server, "state", state)
+
+    server.make_app(
+        auth_expire_days=14,
+        auth_login_slack_notify=False,
+        auth_method="anonymous",
+        develop=False,
+        demo=True,
+        host_header_pattern=re.compile(r"localhost(:[0-9]+)?"),
+        owner="anonymous@example.com",
+        slack_bot_token=None,
+        slack_error_advice_rules=[],
+        slack_error_webhook_url="",
+        slack_webhook_url="",
+        url="http://localhost:8888",
+        workspace_status_json=True,
+    )
+
+    assert "nodes_alpha_group_upgrade" in state.workspaces
+
+
 def test_development_server_uses_snapshot_seed_instead_of_synthetic_demo_seed(tmp_path, monkeypatch):
     now = datetime(2026, 6, 3, tzinfo=UTC)
     path = tmp_path / "snapshot.json"
@@ -299,8 +347,8 @@ def test_development_server_uses_snapshot_seed_instead_of_synthetic_demo_seed(tm
         owner="anonymous@example.com",
         slack_bot_token=None,
         slack_error_advice_rules=[],
-        slack_error_webhook_url=None,
-        slack_webhook_url=None,
+        slack_error_webhook_url="",
+        slack_webhook_url="",
         url="http://localhost:8888",
         workspace_status_json=True,
     )


### PR DESCRIPTION
## Summary
- Replaces the boardwalkd dashboard with an ops-focused lane layout for Active, Needs Attention, and Quiet workspaces.
- Adds URL-persisted group, status, source, search, sort, and edit state.
- Adds current-host reporting and streams Ansible task-start events into workspace history during runs.
- Adds generic workspace grouping via `ui_group` and `ui_group_inventory_var`.
- Adds refreshed row expansion, inline event expansion, edit/delete actions, remote cleanup actions, Jenkins source links, and auth-login Slack mentions.
- Adds generic demo/snapshot replay tooling, public-safe snapshot sanitization, theme extension hooks, and a generic favicon.

## Test Plan
- [x] `CI=true poetry run pytest test/boardwalk test/boardwalkd -q`
- [x] `CI=true poetry run ruff check src/boardwalk src/boardwalkd test/boardwalk test/boardwalkd`
- [x] `git diff --check`
- [x] `poetry check`
- [x] `xmllint --noout src/boardwalkd/static/favicon.svg`
- [x] Built wheel and confirmed `boardwalkd/static/favicon.svg` is packaged

## Notes
- Non-CI local pytest requires a running local boardwalkd because of the existing session autouse fixture in `test/conftest.py`.