### PR TITLE
Switch Dependabot to uv for package-ecosystem; schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,15 @@
 version: 2
 updates:
   # To monitor pyproject.toml
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   # For keeping workflows up-to-date.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - "CI/CD"
     commit-message:


### PR DESCRIPTION
## What and why?

Changes the Python package ecosystem to uv, and switches both the Python and GitHub Actions update checks to a weekly schedule.

## How was this tested?

Calibrated eyeballs and [documentation.](https://docs.astral.sh/uv/guides/integration/dependabot/)

## Checklist
- [n/a] Have you updated the `version` in the `[project]` section of
the `pyproject.toml` file (if applicable)?
