### PR TITLE
Validate deployment_url scheme in auth-login prompts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "uv_build"
 name = "boardwalk"
 description = "Boardwalk is a linear Ansible workflow engine"
 readme = "README.md"
-version = "0.9.1"
+version = "0.9.2"
 requires-python = ">=3.13, <4"
 license = "MIT"
 license-files = ["LICENSE", "ATTRIBUTIONS.md"]

--- a/src/boardwalkd/server.py
+++ b/src/boardwalkd/server.py
@@ -670,6 +670,13 @@ def auth_login_context_from_request(handler: tornado.web.RequestHandler) -> dict
         value = handler.get_query_argument(field, default="")
         if value:
             auth_context[field] = value
+    # Reject a deployment_url whose scheme is not http/https before it can be
+    # rendered into an <a href> on the dashboard, mirroring the validation that
+    # WorkspaceDetails.validate_url already applies to the worker-reported value
+    deployment_url = auth_context.get("deployment_url", "")
+    if deployment_url and urlparse(deployment_url).scheme not in ("http", "https"):
+        app_log.warning("Dropping auth-login deployment_url with disallowed URL scheme")
+        del auth_context["deployment_url"]
     return auth_context
 
 

--- a/test/boardwalkd/test_auth_login_context.py
+++ b/test/boardwalkd/test_auth_login_context.py
@@ -1,0 +1,36 @@
+from typing import cast
+
+import tornado.web
+
+from boardwalkd import server
+
+
+class _FakeRequestHandler:
+    """Minimal stand-in exposing get_query_argument for auth_login_context_from_request"""
+
+    def __init__(self, query_args: dict[str, str]):
+        self._query_args = query_args
+
+    def get_query_argument(self, name: str, default: str = "") -> str:
+        return self._query_args.get(name, default)
+
+
+def _handler(query_args: dict[str, str]) -> tornado.web.RequestHandler:
+    return cast(tornado.web.RequestHandler, _FakeRequestHandler(query_args))
+
+
+def test_auth_login_context_drops_deployment_url_with_disallowed_scheme():
+    # A javascript:/data: URL must be dropped so it cannot be rendered into an
+    # <a href> on the dashboard, while the other context fields are preserved
+    context = server.auth_login_context_from_request(
+        _handler({"workspace": "example", "deployment_url": "javascript:alert(document.domain)"})
+    )
+    assert "deployment_url" not in context
+    assert context["workspace"] == "example"
+
+
+def test_auth_login_context_keeps_http_and_https_deployment_url():
+    # Legitimate worker-supplied deployment URLs are unaffected
+    for url in ("https://ci.example/job/1", "http://ci.example/job/1"):
+        context = server.auth_login_context_from_request(_handler({"deployment_url": url}))
+        assert context["deployment_url"] == url


### PR DESCRIPTION
## What

`auth_login_context_from_request` reads the auth-login websocket's query arguments
(including `deployment_url`) and stores them as a pending prompt, which the dashboard
renders into an `<a href="...">` in `index_workspace.html`.

`WorkspaceDetails.validate_url` already restricts `deployment_url` to `http`/`https`
on the worker-details path, but the auth-login path performs no equivalent validation —
so a non-`http(s)` scheme (e.g. `javascript:`) reaches the rendered `href` unchanged.

## Change

- Reject a `deployment_url` whose scheme is not `http`/`https` at the ingestion point
  (`auth_login_context_from_request`), mirroring the existing
  `WorkspaceDetails.validate_url` check. Other context fields are untouched and
  legitimate `http(s)` URLs are unaffected.
- Add unit tests covering both the drop and the pass-through cases.
- Bump the version to `0.9.2` per CONTRIBUTING.

## Testing

- `ruff format --check`, `ruff check`, and `pyright` all clean (0 errors).
- `semgrep` reports no findings.
- `pytest test/boardwalkd` — 71 passed.
