### PR TITLE
stability, security: Improve Slack data caching; mitigate deployment_url XSS

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,12 +31,5 @@ jobs:
       - name: Run default job setup (Checkout, uv, python, install project)
         uses: ./.github/actions/project_setup
 
-      # Run the "semgrep scan" command on the command line of the docker image.
-      - name: Execute semgrep scan command
-        run: >
-          uv run --frozen semgrep scan --config test/semgrep-rules.yml
-          --config "p/r2c-security-audit"
-          --config "p/r2c-bug-scan"
-          --config "p/secrets"
-          --config "p/dockerfile"
-          --metrics off
+      - name: Execute semgrep scan command using the Makefile recipe
+        run: make test-semgrep

--- a/Makefile
+++ b/Makefile
@@ -140,14 +140,11 @@ test-pyright: develop
 # Perform security static analysis
 .PHONY: test-semgrep
 test-semgrep: develop
-ifndef GITHUB_ACTIONS
 	uv run --frozen semgrep \
-		--config test/semgrep-rules.yml \
+		--config semgrep-rules.yml \
 		--config "p/r2c-security-audit" \
 		--config "p/r2c-bug-scan" \
 		--config "p/secrets" \
 		--config "p/dockerfile" \
+		--exclude-rule=generic.html-templates.security.var-in-href.var-in-href \
 		--metrics off
-else
-	echo Semgrep will run in its own GitHub Actions job.
-endif

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "uv_build"
 name = "boardwalk"
 description = "Boardwalk is a linear Ansible workflow engine"
 readme = "README.md"
-version = "0.9.1"
+version = "0.9.2"
 requires-python = ">=3.13, <4"
 license = "MIT"
 license-files = ["LICENSE", "ATTRIBUTIONS.md"]

--- a/semgrep-rules.yml
+++ b/semgrep-rules.yml
@@ -79,3 +79,46 @@ rules:
       @tornado.web.authenticated
       def $METHOD(...):
           ...
+
+- id: boardwalk.html-templates.security.var-in-href
+  comment: Overridden version of Semgrep's
+    `generic.html-templates.security.var-in-href.var-in-href`, customized for
+    Boardwalk's use
+  message: Detected a template variable used in an anchor tag with the 'href'
+    attribute. This allows a malicious actor to input the 'javascript:' URI and
+    is subject to cross- site scripting (XSS) attacks. If this input is from an
+    untrusted source, use `xhtml_escape()` to ensure the string has any
+    potentially unsafe characters escaped.
+  metadata:
+    cwe:
+      - "CWE-79: Improper Neutralization of Input During Web Page Generation
+        ('Cross-site Scripting')"
+    references:
+      - https://www.tornadoweb.org/en/stable/escape.html#tornado.escape.xhtml_escape
+    category: security
+    technology:
+      - html-templates
+    confidence: LOW
+    subcategory:
+      - audit
+    likelihood: LOW
+    impact: MEDIUM
+    vulnerability_class:
+      - Cross-Site-Scripting (XSS)
+  languages:
+    - generic
+  paths:
+    include:
+      - "*.html"
+  severity: WARNING
+  patterns:
+    - pattern-inside: <a ...>
+    - pattern-either:
+        - pattern: href = {{ ... }}
+        - pattern: href = "{{ ... }}"
+        - pattern: href = '{{ ... }}'
+    - pattern-not-inside: href = {{ xhtml_escape(...) ... }}
+    - pattern-not-inside: href = "{{ xhtml_escape(...) ... }}"
+    - pattern-not-inside: href = '{{ xhtml_escape(...) ... }}'
+    - pattern-not-inside: href = "/{{ ... }}"
+    - pattern-not-inside: href = '/{{ ... }}'

--- a/src/boardwalk/cli_run.py
+++ b/src/boardwalk/cli_run.py
@@ -36,6 +36,7 @@ from boardwalk.host import Host, RemoteHostLocked
 from boardwalk.manifest import NoActiveWorkspace, Workspace, get_boardwalkd_url, get_ws
 from boardwalk.state import RemoteStateModel, RemoteStateWorkflow, RemoteStateWorkspace
 from boardwalk.utils import strtobool
+from boardwalkd.auth_prompts import AuthLoginPrompt
 from boardwalkd.protocol import (
     WorkspaceClient,
     WorkspaceDetails,
@@ -712,6 +713,8 @@ def bootstrap_with_server(workspace: Workspace, ctx: click.Context):
         "deployment_user_id": os.environ.get("BUILD_USER_ID"),
         "deployment_user_email": os.environ.get("BUILD_USER_EMAIL"),
     }
+    # The AuthLoginPrompt model is used to validate the deployment_url has a valid url scheme
+    _ = AuthLoginPrompt(client_id="_", login_url="_", auth_context=auth_login_context)
     boardwalkd_client.set_auth_login_context(**{key: value for key, value in auth_login_context.items() if value})
     # Check if the if the Workspace is locked. We don't want to conflict with another worker
     try:

--- a/src/boardwalkd/auth_prompts.py
+++ b/src/boardwalkd/auth_prompts.py
@@ -1,7 +1,10 @@
 from collections.abc import Collection
 from datetime import UTC, datetime
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field
+from loguru import logger
+from pydantic import BaseModel, Field, field_validator
+from pydantic_core import PydanticCustomError
 
 
 class AuthLoginPrompt(BaseModel, extra="forbid"):
@@ -9,18 +12,44 @@ class AuthLoginPrompt(BaseModel, extra="forbid"):
 
     client_id: str
     login_url: str
-    auth_context: dict[str, str] = Field(default_factory=dict)
+    auth_context: dict[str, str | None] = Field(default_factory=dict)
     created_time: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
     @property
     def workspace(self) -> str:
-        return self.auth_context.get("workspace", "")
+        return self.auth_context.get("workspace", "")  # pyright: ignore[reportReturnType]
+
+    @field_validator("auth_context", mode="before")
+    @classmethod
+    def validate_auth_context(cls, auth_context: dict[str, str]):
+        """Field validator for `auth_context`.
+
+        Currently validates:
+          - `deployment_url` - Ensures URL scheme is valid"""
+        valid_url_schemes: list[str] = ["http", "https"]
+        # Check to see if the deployment_url both: a) Exists, and b) is an expected scheme. If not, raise a validation error
+        if (deployment_url := auth_context.get("deployment_url")) and (
+            scheme := urlparse(deployment_url).scheme
+        ) not in valid_url_schemes:
+            logger.error(
+                f"Invalid `deployment_url` scheme received from {auth_context.get('worker_username', 'unknown')}@{auth_context.get('worker_hostname', 'unknown')}; expected one of {valid_url_schemes}; received: {scheme}"
+            )
+            raise PydanticCustomError(
+                "invalid_AuthLoginPrompt_deployment_url_scheme",
+                "auth_context['deployment_url'] failed to validate due to invalid scheme; expected one of {valid_schemes}; parsed [{invalid_scheme}]; the `deployment_url` was: `{deployment_url}`",
+                {
+                    "valid_schemes": valid_url_schemes,
+                    "invalid_scheme": scheme,
+                    "deployment_url": deployment_url,
+                },
+            )
+        return auth_context
 
 
 active_auth_prompts: dict[str, AuthLoginPrompt] = {}
 
 
-def set_auth_prompt(client_id: str, login_url: str, auth_context: dict[str, str]) -> AuthLoginPrompt:
+def set_auth_prompt(client_id: str, login_url: str, auth_context: dict[str, str | None]) -> AuthLoginPrompt:
     """Stores a pending authentication prompt for a given authentication request"""
     prompt = AuthLoginPrompt(client_id=client_id, login_url=login_url, auth_context=auth_context)
     active_auth_prompts[client_id] = prompt

--- a/src/boardwalkd/broadcast.py
+++ b/src/boardwalkd/broadcast.py
@@ -30,7 +30,7 @@ SLACK_USER_LOOKUP_TIMEOUT_SECONDS = 3.0
 SLACK_USER_MENTION_CACHE_TTL_SECONDS = 3600.0
 
 
-def _auth_login_context_fields(auth_context: dict[str, str], server_url: str) -> list[MarkdownTextObject]:
+def _auth_login_context_fields(auth_context: dict[str, str | None], server_url: str) -> list[MarkdownTextObject]:
     """Formats auth login context into Slack fields."""
     fields: list[MarkdownTextObject] = []
     for key, label in AUTH_CONTEXT_LABELS.items():
@@ -47,7 +47,7 @@ def _auth_login_context_fields(auth_context: dict[str, str], server_url: str) ->
 
 async def handle_auth_login_broadcast(
     login_url: str,
-    auth_context: dict[str, str],
+    auth_context: dict[str, str | None],
     webhook_url: str | None,
     error_webhook_url: str | None,
     server_url: str,

--- a/src/boardwalkd/broadcast.py
+++ b/src/boardwalkd/broadcast.py
@@ -2,17 +2,11 @@
 Code for handling server broadcasts
 """
 
-import asyncio
-import time
-from dataclasses import dataclass
-
 from slack_sdk.models.blocks import (
     MarkdownTextObject,
     SectionBlock,
 )
-from slack_sdk.web.async_client import AsyncWebClient
 from slack_sdk.webhook.async_client import AsyncWebhookClient
-from tornado.log import app_log
 
 from boardwalkd.protocol import WorkspaceEvent
 from boardwalkd.slack_error_advice import SlackErrorAdviceRule
@@ -34,15 +28,6 @@ AUTH_CONTEXT_LABELS = {
 
 SLACK_USER_LOOKUP_TIMEOUT_SECONDS = 3.0
 SLACK_USER_MENTION_CACHE_TTL_SECONDS = 3600.0
-
-
-@dataclass
-class SlackUserMentionCacheEntry:
-    mention: str
-    expires_at: float
-
-
-_slack_user_mention_cache: dict[str, SlackUserMentionCacheEntry] = {}
 
 
 def _auth_login_context_fields(auth_context: dict[str, str], server_url: str) -> list[MarkdownTextObject]:
@@ -145,37 +130,3 @@ async def handle_slack_broadcast(
     elif webhook_url:
         webhook_client = AsyncWebhookClient(url=webhook_url)
         await webhook_client.send(blocks=slack_message_blocks)
-
-
-async def slack_user_mention_for_email(email: str | None, slack_bot_token: str | None) -> str | None:
-    """Resolves a Slack mention for an email address using the configured bot token."""
-    if not email or not slack_bot_token or "@" not in email:
-        return None
-
-    normalized_email = email.strip().lower()
-    cached_entry = _slack_user_mention_cache.get(normalized_email)
-    if cached_entry:
-        if cached_entry.expires_at > time.monotonic():
-            return cached_entry.mention
-        del _slack_user_mention_cache[normalized_email]
-
-    client = AsyncWebClient(token=slack_bot_token)
-    try:
-        response = await asyncio.wait_for(
-            client.users_lookupByEmail(email=normalized_email),
-            timeout=SLACK_USER_LOOKUP_TIMEOUT_SECONDS,
-        )
-    except TimeoutError:
-        app_log.warning(f"Timed out resolving Slack user mention for {normalized_email}")
-        return None
-    except Exception as e:
-        app_log.warning(f"Could not resolve Slack user mention for {normalized_email}: {e}")
-        return None
-    user_id = response.get("user", {}).get("id")
-    mention = f"<@{user_id}>" if user_id else None
-    if mention:
-        _slack_user_mention_cache[normalized_email] = SlackUserMentionCacheEntry(
-            mention=mention,
-            expires_at=time.monotonic() + SLACK_USER_MENTION_CACHE_TTL_SECONDS,
-        )
-    return mention

--- a/src/boardwalkd/cli.py
+++ b/src/boardwalkd/cli.py
@@ -298,6 +298,7 @@ def serve(
     logger.remove()
     loglevel = "INFO" if verbose == 0 else "DEBUG" if verbose == 1 else "TRACE"
     logger.add(sys.stdout, level=loglevel)
+    logger.info(f"boardwalkd, version {lib_version('boardwalk')}, is now starting...")
     logger.info(f"Log level is {loglevel}")
 
     logger.warning("boardwalkd is running in development mode, which should not be used in a production environment")

--- a/src/boardwalkd/protocol.py
+++ b/src/boardwalkd/protocol.py
@@ -17,7 +17,8 @@ from urllib.parse import urlencode, urljoin, urlparse
 
 import click
 from loguru import logger
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ValidationInfo, field_validator
+from pydantic_core import PydanticCustomError
 from tornado.httpclient import (
     HTTPClient,
     HTTPClientError,
@@ -80,10 +81,22 @@ class WorkspaceDetails(ProtocolBaseModel):
 
     @field_validator("deployment_url")
     @classmethod
-    def validate_url(cls, url: str):
+    def validate_url(cls, url: str, values: ValidationInfo):
+        """Field validator for deployment_url"""
         valid_url_schemes: list[str] = ["http", "https"]
-        if url and urlparse(url).scheme not in valid_url_schemes:
-            raise ValueError(f"Invalid URL scheme for deployment_url; must be one of {valid_url_schemes}")
+        if url and (scheme := urlparse(url).scheme) not in valid_url_schemes:
+            logger.error(
+                f"Invalid `deployment_url` scheme received from {values.data.get('worker_username', 'unknown')}@{values.data.get('worker_hostname', 'unknown')}; expected one of {valid_url_schemes}; received: {scheme}"
+            )
+            raise PydanticCustomError(
+                "invalid_WorkspaceDetails_deployment_url_scheme",
+                "`deployment_url` failed to validate due to invalid scheme; expected one of {valid_schemes}; parsed [{invalid_scheme}]; the `deployment_url` was: `{deployment_url}`",
+                {
+                    "valid_schemes": valid_url_schemes,
+                    "invalid_scheme": scheme,
+                    "url": url,
+                },
+            )
         return url
 
 

--- a/src/boardwalkd/server.py
+++ b/src/boardwalkd/server.py
@@ -327,7 +327,7 @@ class UserRoleHandler(AdminUIBaseHandler):
 class AnonymousLoginHandler(UIBaseHandler):
     """Handles "logging in" the UI when no auth is actually configured"""
 
-    # nosemgrep: test.boardwalk.python.security.handler-method-missing-authentication
+    # nosemgrep: boardwalk.python.security.handler-method-missing-authentication
     async def get(self):  # pyright: ignore [reportIncompatibleMethodOverride]
         # Save the user to the state if they aren't already in there
         anon_username = "anonymous@example.com"
@@ -353,7 +353,7 @@ class GoogleOAuth2LoginHandler(UIBaseHandler, tornado.auth.GoogleOAuth2Mixin):
 
     url_encryption_key = Fernet.generate_key()
 
-    # nosemgrep: test.boardwalk.python.security.handler-method-missing-authentication
+    # nosemgrep: boardwalk.python.security.handler-method-missing-authentication
     async def get(self, *args: Any, **kwargs: Any):
         try:
             # If the request is sent along with a code, then we assume the code
@@ -663,9 +663,9 @@ class AuthLoginApiWebsocketIDNotFound(Exception):
     """The auth login client socket was not found"""
 
 
-def auth_login_context_from_request(handler: tornado.web.RequestHandler) -> dict[str, str]:
+def auth_login_context_from_request(handler: tornado.web.RequestHandler) -> dict[str, str | None]:
     """Gets worker context from the auth login websocket query arguments."""
-    auth_context: dict[str, str] = {}
+    auth_context: dict[str, str | None] = {}
     for field in AUTH_LOGIN_CONTEXT_FIELDS:
         value = handler.get_query_argument(field, default="")
         if value:
@@ -673,7 +673,7 @@ def auth_login_context_from_request(handler: tornado.web.RequestHandler) -> dict
     return auth_context
 
 
-async def notify_auth_login(login_url: str, auth_context: dict[str, str], settings: dict[str, Any]):
+async def notify_auth_login(login_url: str, auth_context: dict[str, str | None], settings: dict[str, Any]):
     """Posts an auth-login notification without interrupting the websocket flow."""
     try:
         if deployment_user_email := auth_context.get("deployment_user_email", ""):
@@ -783,7 +783,7 @@ class AuthApiDenied(APIBaseHandler):
     """Dedicated handler for redirecting an unauthenticated user to an 'access
     denied' endpoint"""
 
-    # nosemgrep: test.boardwalk.python.security.handler-method-missing-authentication
+    # nosemgrep: boardwalk.python.security.handler-method-missing-authentication
     def get(self):
         return self.send_error(403)
 
@@ -791,14 +791,14 @@ class AuthApiDenied(APIBaseHandler):
 class DevelopmentClearAllWorkspaces(APIBaseHandler):
     """When run in development mode, allows clearing all workspaces"""
 
-    # nosemgrep: test.boardwalk.python.security.handler-method-missing-authentication
+    # nosemgrep: boardwalk.python.security.handler-method-missing-authentication
     def get(self):
         if self.settings.get("development_features_enabled", False):
             return self.send_error(405)
         else:
             return self.send_error(403)
 
-    # nosemgrep: test.boardwalk.python.security.handler-method-missing-authentication
+    # nosemgrep: boardwalk.python.security.handler-method-missing-authentication
     def post(self):
         if self.settings.get("development_features_enabled", False):
             ws_names = [name for name, _ in state.workspaces.items()]
@@ -817,7 +817,7 @@ class DevelopmentClearAllWorkspaces(APIBaseHandler):
 class WorkspacesStatusApiHandler(APIBaseHandler):
     """Returns an unauthenticated, read-only summary of all workspaces for monitoring integrations"""
 
-    # nosemgrep: test.boardwalk.python.security.handler-method-missing-authentication
+    # nosemgrep: boardwalk.python.security.handler-method-missing-authentication
     def get(self):
         if not self.settings.get("workspace_status_json"):
             return self.send_error(404)
@@ -1166,10 +1166,11 @@ def make_app(
         "api_access_denied_url": urljoin(url, "/api/auth/denied"),
         "auth_expire_days": auth_expire_days,
         "auth_login_slack_notify": auth_login_slack_notify,
+        "development_features_enabled": develop,
+        "jenkins_job_url": jenkins_job_url,
         "login_url": urljoin(url, "/auth/login"),
         "log_function": log_request,
         "owner": owner,
-        "development_features_enabled": develop,
         "slack_bot_token": slack_bot_token,
         "slack_error_advice_rules": slack_error_advice_rules,
         "slack_webhook_url": slack_webhook_url,
@@ -1186,10 +1187,9 @@ def make_app(
             "sha256": ui_method_sha256,
             "sort_events_by_date": ui_method_sort_events_by_date,
         },
-        "jenkins_job_url": jenkins_job_url,
-        "workspace_status_json": workspace_status_json,
         "url": urlparse(url),
         "websocket_ping_interval": 10,
+        "workspace_status_json": workspace_status_json,
         "xsrf_cookies": True,
         "xsrf_cookie_kwargs": {"samesite": "Strict", "secure": True},
     }

--- a/src/boardwalkd/server.py
+++ b/src/boardwalkd/server.py
@@ -41,7 +41,7 @@ from boardwalkd.auth_prompts import (
     prompts_by_workspace,
     set_auth_prompt,
 )
-from boardwalkd.broadcast import handle_auth_login_broadcast, handle_slack_broadcast, slack_user_mention_for_email
+from boardwalkd.broadcast import handle_auth_login_broadcast, handle_slack_broadcast
 from boardwalkd.dashboard import (
     DashboardFilters,
     action_url,
@@ -676,20 +676,18 @@ def auth_login_context_from_request(handler: tornado.web.RequestHandler) -> dict
 async def notify_auth_login(login_url: str, auth_context: dict[str, str], settings: dict[str, Any]):
     """Posts an auth-login notification without interrupting the websocket flow."""
     try:
-        slack_user_mention = await slack_user_mention_for_email(
-            auth_context.get("deployment_user_email"),
-            settings.get("slack_bot_token"),
-        )
-        await handle_auth_login_broadcast(
-            login_url=login_url,
-            auth_context=auth_context,
-            webhook_url=settings.get("slack_webhook_url"),
-            error_webhook_url=settings.get("slack_error_webhook_url"),
-            server_url=settings["url"].geturl(),
-            slack_user_mention=slack_user_mention,
-        )
+        if deployment_user_email := auth_context.get("deployment_user_email", ""):
+            slack_user_mention = state.users[deployment_user_email].slack_cache.user_mention
+            await handle_auth_login_broadcast(
+                login_url=login_url,
+                auth_context=auth_context,
+                webhook_url=settings.get("slack_webhook_url"),
+                error_webhook_url=settings.get("slack_error_webhook_url"),
+                server_url=settings["url"].geturl(),
+                slack_user_mention=slack_user_mention,
+            )
     except Exception as e:
-        app_log.error(f"Could not send auth login Slack notification: {e}")
+        logger.error(f"Could not send auth login Slack notification: {e}")
 
 
 class AuthLoginApiHandler(UIBaseHandler):
@@ -1044,10 +1042,12 @@ class WorkspaceEventApiHandler(APIBaseHandler):
                 workspace_details = state.workspaces[workspace].details
                 slack_user_mention = None
                 if event.severity == "error":
-                    slack_user_mention = await slack_user_mention_for_email(
-                        workspace_details.deployment_user_email,
-                        self.settings.get("slack_bot_token"),
-                    )
+                    if workspace_details.deployment_user_email:
+                        slack_user_mention = state.users[
+                            workspace_details.deployment_user_email
+                        ].slack_cache.user_mention
+                    else:
+                        slack_user_mention = None
                 await handle_slack_broadcast(
                     event,
                     workspace,

--- a/src/boardwalkd/slack.py
+++ b/src/boardwalkd/slack.py
@@ -2,6 +2,7 @@
 Contains functions to handle Slack command handling
 """
 
+import asyncio
 import re
 from collections.abc import Awaitable, Callable, Sequence
 from datetime import UTC, datetime
@@ -42,7 +43,43 @@ from boardwalkd.server import SERVER_URL, SLACK_SLASH_COMMAND_PREFIX, SLACK_TOKE
 from boardwalkd.server import state as STATE
 from boardwalkd.utils import count_of_workspaces_caught, list_active_workspaces, list_inactive_workspaces
 
+SLACK_DATA_CACHE_REFRESH_INTERVAL: float = 60 * 60 * 2  # 2 hours
+
 app = AsyncApp(token=SLACK_TOKENS.get("bot"))
+
+
+async def update_cached_slack_data(limit: int = 200, cursor: str | None = None) -> None:
+    """Asynchronously retrieves the Slack workspace's list of users, and for each user which
+    exists in `boardwalkd`'s state, updates certain data. Runs in a scheduled loop.
+
+    Relies on a match between the email in the Boardwalk state and Slack to determine a match.
+
+    :param str | None cursor: Used when retrieving the next page of paginated results"""
+    while True:
+        try:
+            logger.info("Processing cached Slack data updates...")
+            resp = await app.client.users_list(cursor=cursor, limit=limit)
+            next_cursor = resp.get("response_metadata", {}).get("next_cursor")
+            should_flush_state = False
+            for member in resp.get("members", {}):
+                if email := member.get("profile", {}).get("email"):
+                    if email in STATE.users:
+                        logger.debug(f"Updating cached Slack data for {email}")
+                        STATE.users[email].slack_cache.user_id = member.get("id")
+                        STATE.users[email].slack_cache.real_name = member.get("profile", {}).get("real_name", "Unknown")
+                        should_flush_state = True
+            if should_flush_state:
+                STATE.flush()
+            if next_cursor:
+                logger.trace("Waiting to retrieve next data page...")
+                await asyncio.sleep(10)
+                await update_cached_slack_data(cursor=next_cursor)
+        except SlackApiError as e:
+            logger.error(f"An error was encountered processing cached Slack data updates; error was {e}")
+
+        logger.trace(f"Queueing next cache update to run in {SLACK_DATA_CACHE_REFRESH_INTERVAL} seconds")
+        await asyncio.sleep(SLACK_DATA_CACHE_REFRESH_INTERVAL)
+        await update_cached_slack_data()
 
 
 async def middleware_verify_authorized_boardwalk_user(
@@ -53,7 +90,6 @@ async def middleware_verify_authorized_boardwalk_user(
     client: AsyncWebClient,
     context: AsyncBoltContext,
     next: Callable[[], Awaitable[BoltResponse]],
-    # payload: dict[str, Any],
 ):
     """Middleware for Slack app functions to verify if a given user has authenticated to Boardwalk.
 
@@ -61,10 +97,9 @@ async def middleware_verify_authorized_boardwalk_user(
     """
     slack_user_id = context.get("user_id", "")
     trigger_id = body.get("trigger_id", "")
-    slack_user_profile = await client.users_info(user=slack_user_id)
-    slack_user_email = slack_user_profile.get("user", {}).get("profile", {}).get("email")
-    if slack_user_email in STATE.users.keys():
-        context["boardwalk_user_email"] = slack_user_email
+    user = STATE.get_user_by_slack_id(slack_user_id=slack_user_id)
+    if user is not None:
+        context["boardwalk_user_email"] = user.email
         return await next()
     else:
         await ack()
@@ -75,13 +110,13 @@ async def middleware_verify_authorized_boardwalk_user(
         failure_info = {
             "attempted_action": attempted_action,
             "slack_user_id": slack_user_id,
-            "slack_user_email": slack_user_email,
         }
         if trigger_id:
             logger.warning(f"Not processing request from user due to missing authentication: {failure_info}")
             auth_fail_msg = [
-                f"Apologies, <@{slack_user_id}>, however the email associated with your Slack account -- {slack_user_email} -- does not exist within the Boardwalk's user list, and thus, are not allowed to perform that action.",
+                f"Apologies, <@{slack_user_id}>, however the email associated with your Slack account does not appear to exist within the Boardwalk's user list. Consequently, you are not allowed to perform that action.",
                 f"You will need to visit the Boardwalk Dashboard at {SERVER_URL}, and log in to authenticate.",
+                "If you believe this message was received in error, please try again in a moment.",
             ]
             modal_view = View(
                 title="Authentication Required",
@@ -611,4 +646,6 @@ async def dummy_slack_acknowledgement_handler(ack: AsyncAck):
 
 async def connect() -> None:
     handler = AsyncSocketModeHandler(app=app, app_token=SLACK_TOKENS.get("app"))
+    # Initiate scheduled cache updates
+    asyncio.create_task(update_cached_slack_data())
     await handler.connect_async()

--- a/src/boardwalkd/state.py
+++ b/src/boardwalkd/state.py
@@ -7,7 +7,9 @@ from collections import deque
 from datetime import datetime
 from pathlib import Path
 
-from pydantic import BaseModel, EmailStr, field_validator
+import click
+from loguru import logger
+from pydantic import BaseModel, EmailStr, Field, ValidationError, computed_field, field_validator
 
 from boardwalkd.protocol import WorkspaceDetails, WorkspaceEvent, WorkspaceSemaphores
 
@@ -21,12 +23,28 @@ class StateBaseModel(BaseModel, extra="forbid"):
     """BaseModel for state usage"""
 
 
+class CachedSlackData(StateBaseModel):
+    """Model for certain Slack data frequently used in the application"""
+
+    user_id: str | None = None
+    real_name: str | None = None
+
+    @computed_field(exclude_if=lambda v: 1 == 1)
+    @property
+    def user_mention(self) -> str | None:
+        """Property that returns the user-mention string for this :class:`User`.
+
+        Not stored in the statefile, as it is based on the user_id."""
+        return f"<@{self.user_id}>" if self.user_id is not None else None
+
+
 class User(StateBaseModel):
     """Model for user metadata"""
 
     enabled: bool = True
     email: EmailStr
     roles: set[str] = {"default"}
+    slack_cache: CachedSlackData = Field(default=CachedSlackData())
 
     @field_validator("roles")
     @classmethod
@@ -65,6 +83,17 @@ class State(StateBaseModel):
     workspaces: dict[str, WorkspaceState] = {}
     users: dict[str, User] = {}
 
+    def get_user_by_slack_id(self, slack_user_id) -> User | None:
+        """Retrieves a :class:`User` from the :class:`State` via their Slack User ID, provided the user is active in the `boardwalkd` state.
+
+        :param str slack_user_id: The Slack User ID of the User to retrieve."""
+        for user in self.users.values():
+            if user.enabled and user.slack_cache.user_id == slack_user_id:
+                logger.trace(f"Retrieved cached Slack data for {slack_user_id}")
+                return user
+        # If no such user exists, just return None
+        return None
+
     def flush(self):
         """
         Writes state to disk for persistence
@@ -80,6 +109,12 @@ def load_state() -> State:
     try:
         with open(statefile_path) as fd:
             return State().model_validate_json(fd.read())
+    except ValidationError as e:
+        click.echo(click.style(f"[WARN] Error when validating stored state...\n{e}", fg="yellow"), err=True)
+        click.echo(click.style("[INFO] Resetting state and continuing...", fg="yellow"), err=True)
+        state = State()
+        state.flush()
+        return state
     except FileNotFoundError:
         statefile_dir_path.mkdir(parents=True, exist_ok=True)
         state = State()

--- a/src/boardwalkd/templates/base.html
+++ b/src/boardwalkd/templates/base.html
@@ -13,7 +13,7 @@
     <link href="{{ static_url('bootstrap.min.css') }}" rel="stylesheet">
     <link href="{{ static_url('boardwalkd.css') }}" rel="stylesheet">
     {% if theme_css_url %}
-    <link href="{{ theme_css_url # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}" rel="stylesheet">
+    <link href="{{ theme_css_url # nosemgrep: boardwalk.html-templates.security.var-in-href }}" rel="stylesheet">
     {% end %}
 
     <title>{{ theme_brand_name }} · {{ title }}</title>
@@ -34,7 +34,7 @@
     <header class="bw-topbar">
         <a href="/" class="bw-brand" aria-label="{{ theme_brand_name }}">
             {% if theme_logo_url %}
-            <img src="{{ theme_logo_url # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}" alt="{{ theme_logo_alt or theme_brand_name }}" class="bw-brand-mark">
+            <img src="{{ theme_logo_url # nosemgrep: boardwalk.html-templates.security.var-in-href }}" alt="{{ theme_logo_alt or theme_brand_name }}" class="bw-brand-mark">
             {% else %}
             <span class="bw-brand-mark bw-brand-mark-text">B</span>
             {% end %}

--- a/src/boardwalkd/templates/index_workspace.html
+++ b/src/boardwalkd/templates/index_workspace.html
@@ -4,7 +4,7 @@
     <nav class="bw-tabs" aria-label="Workspace groups">
         {% for group in dashboard.groups %}
         <a class="bw-tab{% if group.active %} is-active{% end %}"
-            href="{{ canonical_url(filters, edit=edit, group=group.label) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
+            href="{{ canonical_url(filters, edit=edit, group=group.label) # nosemgrep: boardwalk.html-templates.security.var-in-href }}"
             hx-get="{{ partial_url(filters, edit=edit, push_url=True, group=group.label) }}"
             hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false">
             <span>{{ group.label }}</span>
@@ -82,11 +82,11 @@
 
         <div class="bw-filter-actions">
             {% if edit %}
-            <a class="bw-button bw-button-secondary" href="{{ canonical_url(filters) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
+            <a class="bw-button bw-button-secondary" href="{{ canonical_url(filters) # nosemgrep: boardwalk.html-templates.security.var-in-href }}"
                 hx-get="{{ partial_url(filters, push_url=True) }}" hx-target="closest .bw-frame"
                 hx-swap="innerHTML" hx-push-url="false">Exit edit</a>
             {% else %}
-            <a class="bw-button bw-button-secondary" href="{{ canonical_url(filters, edit=True) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
+            <a class="bw-button bw-button-secondary" href="{{ canonical_url(filters, edit=True) # nosemgrep: boardwalk.html-templates.security.var-in-href }}"
                 hx-get="{{ partial_url(filters, edit=True, push_url=True) }}" hx-target="closest .bw-frame"
                 hx-swap="innerHTML" hx-push-url="false">Edit</a>
             {% end %}
@@ -102,11 +102,11 @@
             <span>{% if prompt.auth_context.get('worker_command') %}{{ prompt.auth_context.get('worker_command') }}{% else %}&lt;unknown command&gt;{% end %}</span>
             <span>{% if prompt.auth_context.get('worker_limit') %}{{ prompt.auth_context.get('worker_limit') }}{% else %}&lt;unknown limit&gt;{% end %}</span>
             {% if prompt.auth_context.get('deployment_url') %}
-            <a href="{{ prompt.auth_context.get('deployment_url') # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}">Deployment</a>
+            <a href="{{ xhtml_escape(prompt.auth_context.get('deployment_url')) }}">Deployment</a>
             {% else %}
             <span>Deployment unavailable</span>
             {% end %}
-            <a href="{{ prompt.login_url # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}" class="bw-button bw-button-catch">Open login</a>
+            <a href="{{ prompt.login_url # nosemgrep: boardwalk.html-templates.security.var-in-href }}" class="bw-button bw-button-catch">Open login</a>
         </div>
         {% end %}
     </section>
@@ -133,7 +133,7 @@
                         <span class="bw-sort">
                             <span class="bw-sort-label">Workspace</span>
                             <a class="bw-sort-arrow{% if filters.sort == 'workspace' %} is-active{% end %}"
-                                href="{{ sort_url('/', filters, 'workspace', edit=edit) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
+                                href="{{ sort_url('/', filters, 'workspace', edit=edit) # nosemgrep: boardwalk.html-templates.security.var-in-href }}"
                                 hx-get="{{ sort_url('/workspaces', filters, 'workspace', edit=edit, push_url='1') }}"
                                 hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
                                 aria-label="{% if filters.sort == 'workspace' %}Workspace sorted {{ filters.direction }}; switch sort direction{% else %}Workspace sorted by default; sort by workspace{% end %}">
@@ -143,7 +143,7 @@
                         <span class="bw-sort bw-sort-subtle">
                             <span class="bw-sort-label">Latest</span>
                             <a class="bw-sort-arrow{% if filters.sort == 'updated' %} is-active{% end %}"
-                                href="{{ sort_url('/', filters, 'updated', edit=edit) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
+                                href="{{ sort_url('/', filters, 'updated', edit=edit) # nosemgrep: boardwalk.html-templates.security.var-in-href }}"
                                 hx-get="{{ sort_url('/workspaces', filters, 'updated', edit=edit, push_url='1') }}"
                                 hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
                                 aria-label="{% if filters.sort == 'updated' %}Latest event sorted {{ filters.direction }}; switch sort direction{% else %}Latest event sorted by default; sort by latest event{% end %}">
@@ -155,7 +155,7 @@
                     <span class="bw-sort">
                         <span class="bw-sort-label">Current host</span>
                         <a class="bw-sort-arrow{% if filters.sort == 'current_host' %} is-active{% end %}"
-                            href="{{ sort_url('/', filters, 'current_host', edit=edit) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
+                            href="{{ sort_url('/', filters, 'current_host', edit=edit) # nosemgrep: boardwalk.html-templates.security.var-in-href }}"
                             hx-get="{{ sort_url('/workspaces', filters, 'current_host', edit=edit, push_url='1') }}"
                             hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
                             aria-label="{% if filters.sort == 'current_host' %}Current host sorted {{ filters.direction }}; switch sort direction{% else %}Current host sorted by default; sort by current host{% end %}">
@@ -165,7 +165,7 @@
                     <span class="bw-sort">
                         <span class="bw-sort-label">Source</span>
                         <a class="bw-sort-arrow{% if filters.sort == 'source' %} is-active{% end %}"
-                            href="{{ sort_url('/', filters, 'source', edit=edit) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
+                            href="{{ sort_url('/', filters, 'source', edit=edit) # nosemgrep: boardwalk.html-templates.security.var-in-href }}"
                             hx-get="{{ sort_url('/workspaces', filters, 'source', edit=edit, push_url='1') }}"
                             hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
                             aria-label="{% if filters.sort == 'source' %}Source sorted {{ filters.direction }}; switch sort direction{% else %}Source sorted by default; sort by source{% end %}">
@@ -175,7 +175,7 @@
                     <span class="bw-sort">
                         <span class="bw-sort-label">Status</span>
                         <a class="bw-sort-arrow{% if filters.sort == 'status' %} is-active{% end %}"
-                            href="{{ sort_url('/', filters, 'status', edit=edit) # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}"
+                            href="{{ sort_url('/', filters, 'status', edit=edit) # nosemgrep: boardwalk.html-templates.security.var-in-href }}"
                             hx-get="{{ sort_url('/workspaces', filters, 'status', edit=edit, push_url='1') }}"
                             hx-target="closest .bw-frame" hx-swap="innerHTML" hx-push-url="false"
                             aria-label="{% if filters.sort == 'status' %}Status sorted {{ filters.direction }}; switch sort direction{% else %}Status sorted by default; sort by status{% end %}">
@@ -216,7 +216,7 @@
             </div>
             <div class="bw-source" role="cell">
                 {% if row.source_url %}
-                <a href="{{ row.source_url # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}" target="_blank" rel="noreferrer">{{ row.source_label }}</a>
+                <a href="{{ row.source_url # nosemgrep: boardwalk.html-templates.security.var-in-href }}" target="_blank" rel="noreferrer">{{ row.source_label }}</a>
                 {% else %}
                 <span class="bw-source-label">{{ row.source_label }}</span>
                 {% end %}
@@ -254,9 +254,9 @@
                     <span>User: {{ prompt.auth_context.get('deployment_user') }}</span>
                     {% end %}
                     {% if prompt.auth_context.get('deployment_url') %}
-                    <a href="{{ prompt.auth_context.get('deployment_url') # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}">Deployment</a>
+                    <a href="{{ xhtml_escape(prompt.auth_context.get('deployment_url')) }}">Deployment</a>
                     {% end %}
-                    <a href="{{ prompt.login_url # nosemgrep: generic.html-templates.security.var-in-href.var-in-href }}" class="bw-button bw-button-catch">Open login</a>
+                    <a href="{{ prompt.login_url # nosemgrep: boardwalk.html-templates.security.var-in-href }}" class="bw-button bw-button-catch">Open login</a>
                 </div>
                 {% end %}
             </div>

--- a/test/boardwalkd/test_auth_prompts.py
+++ b/test/boardwalkd/test_auth_prompts.py
@@ -1,0 +1,39 @@
+import pytest
+from pydantic_core import ValidationError
+
+from boardwalkd.auth_prompts import AuthLoginPrompt
+
+
+@pytest.mark.parametrize(
+    ("url"),
+    [
+        pytest.param(""),
+        pytest.param("http://jenkins.example.network"),
+        pytest.param("https://jenkins.example.network"),
+    ],
+)
+def test_AuthLoginPrompt_accepts_deployment_url_with_valid_scheme(url: str):
+    """We expect that any valid deployment_url in the auth_context is present from an instantiated :class:`AuthLoginPrompt`"""
+    auth_login_prompt = AuthLoginPrompt(
+        client_id="123", login_url="https://foobar.example", auth_context=dict({"deployment_url": url})
+    )
+    assert auth_login_prompt.auth_context["deployment_url"] == url
+
+
+@pytest.mark.parametrize(
+    ("url"),
+    [
+        pytest.param("javascript:alert(document.domain)"),
+        pytest.param("data:,Hello%2C%20World%21"),
+        pytest.param("httpx://jenkins.example.network"),
+    ],
+)
+def test_AuthLoginPrompt_raises_when_invalid_url_scheme_provided(url: str):
+    """We expect that any invalid schema in the auth_context's deployment_url is rejected with a Pydantic validation error"""
+    with pytest.raises(ValidationError) as exc_info:
+        _ = AuthLoginPrompt(
+            client_id="123", login_url="https://foobar.example", auth_context=dict({"deployment_url": url})
+        )
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert errors[0]["type"] == "invalid_AuthLoginPrompt_deployment_url_scheme"

--- a/test/boardwalkd/test_broadcast.py
+++ b/test/boardwalkd/test_broadcast.py
@@ -1,39 +1,7 @@
-from urllib.parse import urlparse
-
 import pytest
 
 import boardwalkd.broadcast as broadcast
-import boardwalkd.server as server
 from boardwalkd.broadcast import handle_auth_login_broadcast
-
-
-@pytest.mark.anyio
-async def test_notify_auth_login_resolves_deployment_user_email_for_slack_mention(monkeypatch):
-    captured = {}
-
-    async def fake_slack_user_mention_for_email(email, slack_bot_token):
-        captured["lookup"] = (email, slack_bot_token)
-        return "<@U123>"
-
-    async def fake_handle_auth_login_broadcast(**kwargs):
-        captured["broadcast"] = kwargs
-
-    monkeypatch.setattr(server, "slack_user_mention_for_email", fake_slack_user_mention_for_email)
-    monkeypatch.setattr(server, "handle_auth_login_broadcast", fake_handle_auth_login_broadcast)
-
-    await server.notify_auth_login(
-        login_url="https://boardwalk.example/api/auth/login?id=abc",
-        auth_context={"deployment_user_email": "lo@example.com"},
-        settings={
-            "slack_webhook_url": "https://hooks.example/general",
-            "slack_error_webhook_url": "https://hooks.example/error",
-            "slack_bot_token": "xoxb-test",
-            "url": urlparse("https://boardwalk.example"),
-        },
-    )
-
-    assert captured["lookup"] == ("lo@example.com", "xoxb-test")
-    assert captured["broadcast"]["slack_user_mention"] == "<@U123>"
 
 
 @pytest.mark.anyio

--- a/test/boardwalkd/test_protocol.py
+++ b/test/boardwalkd/test_protocol.py
@@ -1,0 +1,35 @@
+import pytest
+from pydantic_core import ValidationError
+
+from boardwalkd.protocol import WorkspaceDetails
+
+
+@pytest.mark.parametrize(
+    ("url"),
+    [
+        pytest.param(""),
+        pytest.param("http://jenkins.example.network"),
+        pytest.param("https://jenkins.example.network"),
+    ],
+)
+def test_WorkspaceDetails_accepts_deployment_url_with_valid_scheme(url: str):
+    """We expect that any valid deployment_url in the auth_context is present from an instantiated :class:`AuthLoginPrompt`"""
+    workspace_details = WorkspaceDetails(deployment_url=url)
+    assert workspace_details.deployment_url == url
+
+
+@pytest.mark.parametrize(
+    ("url"),
+    [
+        pytest.param("javascript:alert(document.domain)"),
+        pytest.param("data:,Hello%2C%20World%21"),
+        pytest.param("httpx://jenkins.example.network"),
+    ],
+)
+def test_WorkspaceDetails_raises_when_invalid_url_scheme_provided(url: str):
+    """We expect that any invalid schema in the auth_context's deployment_url is rejected with a Pydantic validation error"""
+    with pytest.raises(ValidationError) as exc_info:
+        _ = WorkspaceDetails(deployment_url=url)
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert errors[0]["type"] == "invalid_WorkspaceDetails_deployment_url_scheme"

--- a/uv.lock
+++ b/uv.lock
@@ -1520,16 +1520,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What and why?

Two items are addressed in this PR.

### boardwalkd: store cached slack data in server-side statefile

Stores certain Slack data about users in a cache in state. Previously,
we were reaching out to Slack in two different places, and -- potentially
due to rate limits -- it was observed that user mentions did not always
get populated.

Here, we opt to have a scheduled task run once every two hours to retrieve
a list of users in the connected Slack workspace, and update the cached
data in the `boardwalkd` state when a match is found.

This more resillient method of trying to avoid the Slack API means there may
be a bit of a delay between a new user and events such as:
- User mentions when notifying of errors or pending authentication requests.
- A new user authenticating to Boardwalk's web UI, and being able to catch/release
  workspaces via the Slack integration.

On the upside, this does eliminate any delay on Slack's API when processing
the authentication middleware requests for Slack, since we just use
already cached data to determine if a Slack account should have access
to catch/release workspaces.

### security: Ensure deployment_url scheme is correct, and xhtml_escaped

This commit fixes an XSS in `boardwalkd`, caused by lack of escaping
of the `deployment_url` when rendering the URL into the template.
This is remedied by:
- Validating that the URL scheme is one of [http, https] via the
  AuthLoginPrompt model using Pydantic field validation; and
- Using `xhtml_escape` to wrap the `deployment_url`, to ensure that
  attempted insertion of unexpected HTML is avoided.

Further, the Semgrep rules are tweaked to disable the generic `var-in-href`
rule, and instead use a Boardwalk-specific rule, allowing for detecting when
`xhtml_escape(...)` is not used; additionally, the two `nosemgrep` excludes
for the offending items were removed, since they now pass the modified rule.

This release is compatible with prior `boardwalk` versions, however
older clients that provide an incorrect scheme will see the exception
ConnectionAbortedError raised upon attempting to bootstrap with boardwalkd,
instead of a descriptive ValidationError raised during model validation.

Reported by @taylorodell in https://github.com/Backblaze/boardwalk/pull/251

## How was this tested?
`make test`, and providing invalid input for `BUILD_URL` envvar when running `boardwalk run`.

## Checklist
- [x] Have you updated the `version` in the `[project]` section of
the `pyproject.toml` file (if applicable)?
