### PR TITLE
boardwalkd (ui): add progress indicator to workflow details

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,6 +35,10 @@
             "cwd": "${workspaceFolder}/test/server-client/",
             "program": "${workspaceFolder}/src/boardwalk/__main__.py",
             "args": "${input:boardwalkCustomCommand}",
+            "env": {
+                // Override any default environ which is True, and ensure the developer has full control (e.g., use -K or -nK)
+                "ANSIBLE_BECOME_ASK_PASS": "False"
+            },
             "justMyCode": true,
         }
     ],

--- a/src/boardwalk/cli_run.py
+++ b/src/boardwalk/cli_run.py
@@ -287,6 +287,8 @@ def run_workflow(
                     ctx=ctx,
                     current_host=host.name,
                     inventory_vars=inventory_vars,
+                    progress_hosts_total=str(len(hosts)),
+                    progress_hosts_completed=str(i),
                 )
             )
 
@@ -353,6 +355,19 @@ def run_workflow(
             pass
 
         i += 1
+
+        if boardwalkd_client:
+            # Update the Workspace progress
+            boardwalkd_client.post_details(
+                build_workspace_details(
+                    workspace=workspace,
+                    ctx=ctx,
+                    current_host=host.name,
+                    inventory_vars=inventory_vars,
+                    progress_hosts_total=str(len(hosts)),
+                    progress_hosts_completed=str(i),
+                )
+            )
 
 
 def run_failure_mode_handler(
@@ -666,6 +681,8 @@ def build_workspace_details(
     ctx: click.Context,
     current_host: str = "",
     inventory_vars: HostVarsType | None = None,
+    progress_hosts_completed: str = "",
+    progress_hosts_total: str = "",
 ) -> WorkspaceDetails:
     """Builds worker details posted to boardwalkd."""
     worker_limit = ctx.params.get("limit")
@@ -689,6 +706,8 @@ def build_workspace_details(
         worker_hostname=socket.gethostname(),
         worker_limit=str(worker_limit) if worker_limit else "",
         worker_username=getpass.getuser(),
+        progress_hosts_completed=progress_hosts_completed,
+        progress_hosts_total=progress_hosts_total,
     )
 
 

--- a/src/boardwalkd/dashboard.py
+++ b/src/boardwalkd/dashboard.py
@@ -65,6 +65,8 @@ class DashboardRow:
     has_mutex: bool
     stale: bool
     can_request_remote_cleanup: bool
+    progress_hosts_completed: str
+    progress_hosts_total: str
 
 
 @dataclass(frozen=True)
@@ -223,6 +225,8 @@ def row_for_workspace(
         has_mutex=workspace.semaphores.has_mutex,
         stale=stale,
         can_request_remote_cleanup=workspace.semaphores.caught and connected,
+        progress_hosts_completed=workspace.details.progress_hosts_completed,
+        progress_hosts_total=workspace.details.progress_hosts_total,
     )
 
 

--- a/src/boardwalkd/demo.py
+++ b/src/boardwalkd/demo.py
@@ -25,6 +25,8 @@ class DemoWorkspace:
     worker_hostname: str = "demo-worker-01"
     worker_limit: str = ""
     workflow: str = "DemoWorkflow"
+    progress_hosts_total: str = "1"
+    progress_hosts_completed: str = "0"
 
 
 DEMO_WORKSPACES = [
@@ -66,13 +68,35 @@ DEMO_WORKSPACES = [
         workflow="NodeUpgrade",
     ),
     DemoWorkspace(
-        name="nodes_omega_group_upgrade",
-        ui_group="omega",
+        name="host_progress_not_available",
+        ui_group="host_progress",
+        host_pattern="nodes_delta",
+        current_host="node-delta-a",
+        latest_event="Updating remote state",
+        workflow="ProgressNotAvailable",
+        progress_hosts_total="",
+        progress_hosts_completed="",
+    ),
+    DemoWorkspace(
+        name="host_progress_in_progress",
+        ui_group="host_progress",
+        host_pattern="nodes_delta",
+        current_host="node-delta-a",
+        latest_event="Updating remote state",
+        workflow="ProgressAvailable",
+        progress_hosts_total="73",
+        progress_hosts_completed="27",
+    ),
+    DemoWorkspace(
+        name="host_progress_completed",
+        ui_group="host_progress",
         host_pattern="nodes_omega",
         current_host="node-omega-a",
         latest_event="Host completed successfully; wrapping up",
         severity="success",
         workflow="NodeUpgrade",
+        progress_hosts_total="42",
+        progress_hosts_completed="42",
     ),
     DemoWorkspace(
         name="nodes_theta_group_upgrade",
@@ -215,6 +239,8 @@ def seed_development_workspaces(state: State) -> bool:
                 worker_limit=worker_limit,
                 worker_username="demo",
                 workflow=example.workflow,
+                progress_hosts_completed=example.progress_hosts_completed,
+                progress_hosts_total=example.progress_hosts_total,
             ),
             events=deque(events),
             last_seen=last_seen,

--- a/src/boardwalkd/protocol.py
+++ b/src/boardwalkd/protocol.py
@@ -75,6 +75,8 @@ class WorkspaceDetails(ProtocolBaseModel):
     worker_hostname: str = ""
     worker_limit: str = ""
     worker_username: str = ""
+    progress_hosts_completed: str = ""
+    progress_hosts_total: str = ""
 
     def __init__(self, **kwargs: str):
         super().__init__(**kwargs)

--- a/src/boardwalkd/templates/index_workspace.html
+++ b/src/boardwalkd/templates/index_workspace.html
@@ -291,9 +291,25 @@
                     <span class="bw-detail-label">Current host</span>
                     <span class="bw-detail-value bw-mono">{% if row.current_host %}{{ row.current_host }}{% else %}unknown{% end %}</span>
                 </div>
-                <div class="bw-detail bw-detail-wide">
+                <div class="bw-detail bw-detail">
                     <span class="bw-detail-label">Command</span>
                     <span class="bw-detail-value bw-command">{{ row.command }}</span>
+                </div>
+                <div class="bw-detail bw-detail">
+                    <span class="bw-detail-label">Completed hosts</span>
+                    <span class="bw-detail-value bw-progress">
+                        <label>
+                            {% if row.progress_hosts_completed %}
+                                <progress value="{{ row.progress_hosts_completed }}" max="{{ row.progress_hosts_total }}"></progress>
+                                <dfn title="Hosts which have completed their workflow run">{{ row.progress_hosts_completed }} / {{ row.progress_hosts_total }}</dfn>
+                            {% else %}
+                                {% if row.worker_connected %}
+                                    <progress value="{{ row.progress_hosts_completed }}" max="{{ row.progress_hosts_total }}"></progress>
+                                {% end %}
+                                <dfn title="The boardwalk worker did not report host completion progress">Unknown</dfn>
+                            {% end %}
+                        </label>
+                    </span>
                 </div>
             </div>
 

--- a/test/boardwalk/test_cli_run.py
+++ b/test/boardwalk/test_cli_run.py
@@ -206,9 +206,11 @@ def test_run_workflow_posts_current_host_details_when_each_host_starts(monkeypat
 
     assert [details.current_host for details in client.details] == [
         "node-alpha-a",
+        "node-alpha-a",
+        "node-beta-a",
         "node-beta-a",
     ]
-    assert [details.ui_group for details in client.details] == ["alpha", "beta"]
+    assert [details.ui_group for details in client.details] == ["alpha", "alpha", "beta", "beta"]
 
 
 def test_ansible_runner_run_tasks_passes_event_handler_to_ansible_runner(monkeypatch, tmp_path):

--- a/test/boardwalkd/test_dashboard.py
+++ b/test/boardwalkd/test_dashboard.py
@@ -47,6 +47,8 @@ def ws(
     has_mutex=True,
     last_seen=None,
     events=None,
+    progress_hosts_completed="",
+    progress_hosts_total="",
 ):
     return WorkspaceState(
         details=WorkspaceDetails(
@@ -61,6 +63,8 @@ def ws(
             worker_limit=worker_limit,
             worker_username=worker_username,
             workflow="UpgradeWorkflow",
+            progress_hosts_completed=progress_hosts_completed,
+            progress_hosts_total=progress_hosts_total,
         ),
         events=deque(events or []),
         last_seen=last_seen,
@@ -537,7 +541,37 @@ def render_workspace_partial(dashboard, workspaces=None, edit=False):
     ).decode()
 
 
-def test_workspace_partial_renders_refreshed_rows_without_progress():
+def test_workspace_partial_renders_progress_bar_for_active_ws_when_hosts_not_reported():
+    """Deciphering the function, we currently have compatibility with older Boardwalk clients on newer servers,
+    so we want an indeterminate progress bar displayed when the worker doesn't report that data."""
+    workspaces = {
+        "workspace_alpha": ws(
+            group="alpha",
+            current_host="node-alpha-a",
+            deployment_number="50321",
+            events=[WorkspaceEvent(severity="info", message="Locking remote host")],
+            last_seen=datetime.now(tz=UTC),
+        )
+    }
+    dashboard = build_dashboard(
+        workspaces,
+        DashboardFilters(group="alpha"),
+        jenkins_job_url="https://ci.example/job/boardwalk/",
+    )
+
+    html = render_workspace_partial(dashboard, workspaces)
+
+    assert "workspace_alpha" in html
+    assert "node-alpha-a" in html
+    assert "Locking remote host" in html
+    assert "https://ci.example/job/boardwalk/50321/" in html
+    assert '<progress value="" max=""></progress>' in html
+    assert '<dfn title="the boardwalk worker did not report host completion progress">unknown</dfn>' in html.lower()
+
+
+def test_workspace_partial_renders_no_progress_bar_for_inactive_ws_when_hosts_not_reported():
+    """Deciphering the function, we currently have compatibility with older Boardwalk clients on newer servers,
+    so we want an indeterminate progress bar displayed when the worker doesn't report that data."""
     workspaces = {
         "workspace_alpha": ws(
             group="alpha",
@@ -559,8 +593,36 @@ def test_workspace_partial_renders_refreshed_rows_without_progress():
     assert "node-alpha-a" in html
     assert "Locking remote host" in html
     assert "https://ci.example/job/boardwalk/50321/" in html
-    assert "progress" not in html.lower()
-    assert "50%" not in html
+    assert '<progress value="" max=""></progress>' not in html
+    assert '<dfn title="the boardwalk worker did not report host completion progress">unknown</dfn>' in html.lower()
+
+
+def test_workspace_partial_renders_refreshed_rows_with_progress():
+    workspaces = {
+        "workspace_alpha": ws(
+            group="alpha",
+            current_host="node-alpha-a",
+            deployment_number="50321",
+            events=[WorkspaceEvent(severity="info", message="Locking remote host")],
+            progress_hosts_total="42",
+            progress_hosts_completed="21",
+        )
+    }
+    dashboard = build_dashboard(
+        workspaces,
+        DashboardFilters(group="alpha"),
+        jenkins_job_url="https://ci.example/job/boardwalk/",
+    )
+
+    html = render_workspace_partial(dashboard, workspaces)
+
+    assert 'class="bw-row status-idle"' in html
+    assert "workspace_alpha" in html
+    assert "node-alpha-a" in html
+    assert "Locking remote host" in html
+    assert "https://ci.example/job/boardwalk/50321/" in html
+    assert '<progress value="21" max="42"></progress>' in html.lower()
+    assert '<dfn title="hosts which have completed their workflow run">21 / 42</dfn>' in html.lower()
 
 
 def test_workspace_partial_renders_lanes_sort_headers_and_advice():

--- a/test/boardwalkd/test_demo.py
+++ b/test/boardwalkd/test_demo.py
@@ -70,6 +70,7 @@ def test_seed_development_workspaces_sorts_demo_rows_into_group_tabs():
         "beta",
         "delta",
         "gamma",
+        "host_progress",
         "omega",
         "theta",
         "Ungrouped",


### PR DESCRIPTION
## What and why?

Adds a "Completed hosts" block to the workspace details visible when expanding a Workspace in the web UI. This was done as since task execution is reported to the Workspaces' Events, log lines which indicate which host -- e.g., "Workflow iteration on host X of Y" -- are invariably quickly scrolled off screen.

Thus, this change adds `progress_hosts_completed` and `progress_hosts_total` to the Workspace's details, allowing for the web interface to display the progress (for compatible clients).

The server is compatible with clients which do not send host completion data.

Internal reference: OPSYSENG-1804

## How was this tested?

Interactive testing with the development server, plus updating the demo code to inject test workspaces.

Example screenshots from the demo workspace:
<details>
<summary>Active workspace, but progress unavailable</summary>
<img width="1658" height="920" alt="image" src="https://github.com/user-attachments/assets/d36cbb96-8aa3-4214-9b56-788a5cc20985" />
</details>

<details>
<summary>Active workspace, with progress available</summary>
<img width="1478" height="480" alt="image" src="https://github.com/user-attachments/assets/f9f15103-01df-4c71-8a67-8cbe14f137c7" />
</details>

<details>
<summary>Inactive workspace, with progress available</summary>
<img width="1488" height="474" alt="image" src="https://github.com/user-attachments/assets/91becdf1-8c4e-4d36-b14c-7c097632cb89" />
</details>

## Checklist
- [n/a] Have you updated the `version` in the `[project]` section of
the `pyproject.toml` file (if applicable)?
- Will be batched into a forthcoming release.