### PR TITLE
dev, linting: Upgrade Ruff, and lint code accordingly

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -46,11 +46,11 @@ jobs:
 
       - name: Ruff - Linting
         if: steps.linter-setup.conclusion == 'success' && !cancelled()
-        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0 - https://github.com/astral-sh/ruff-action/releases/tag/v4.0.0
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89  # v4.1.0 - https://github.com/astral-sh/ruff-action/releases/tag/v4.1.0
 
       - name: Ruff - Formatting
         if: steps.linter-setup.conclusion == 'success' && !cancelled()
-        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0 - https://github.com/astral-sh/ruff-action/releases/tag/v4.0.0
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89  # v4.1.0 - https://github.com/astral-sh/ruff-action/releases/tag/v4.1.0
         with:
           args: "format --check"
 

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0 - https://github.com/actions/checkout/releases/tag/v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 - https://github.com/actions/checkout/releases/tag/v7.0.1
 
       - name: Proceed to run linters
         id: linter-setup
@@ -63,7 +63,7 @@ jobs:
         python-version: ['3.13', '3.14']
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0 - https://github.com/actions/checkout/releases/tag/v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 - https://github.com/actions/checkout/releases/tag/v7.0.1
 
       - name: Run default job setup (Checkout, uv, python, install project)
         uses: ./.github/actions/project_setup
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0 - https://github.com/actions/checkout/releases/tag/v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 - https://github.com/actions/checkout/releases/tag/v7.0.1
 
       - name: Run default job setup (Checkout, uv, python, install project)
         uses: ./.github/actions/project_setup

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0 - https://github.com/actions/checkout/releases/tag/v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1 - https://github.com/actions/checkout/releases/tag/v7.0.1
 
       - name: Run default job setup (Checkout, uv, python, install project)
         uses: ./.github/actions/project_setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
 ]
 lint = [
     "ansible-lint >= v26.6.0",
-    "ruff >= 0.11.13, <0.12",
+    "ruff>=0.16.0,<0.17",
 ]
 test = [
     "pytest >= 9.0.3, <10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
 ]
 lint = [
     "ansible-lint >= v26.6.0",
-    "ruff>=0.16.0,<0.17",
+    "ruff>=0.16.1,<0.17",
 ]
 test = [
     "pytest >= 9.0.3, <10",

--- a/src/boardwalk/ansible.py
+++ b/src/boardwalk/ansible.py
@@ -72,10 +72,7 @@ def ansible_runner_cancel_callback(ws: Workspace):
     True to stop execution. We check for the workspace.mutex because that file
     is always supposed to be torn down on exit
     """
-    if ws.path.joinpath("workspace.mutex").exists():
-        return False
-    else:
-        return True
+    return not ws.path.joinpath("workspace.mutex").exists()
 
 
 FAILED_RUNNER_EVENTS = {
@@ -171,13 +168,14 @@ def ansible_runner_run_tasks(
     quiet: bool = True,
     timeout: int | None = None,
     verbosity: int = 0,
-    extra_vars: dict = {},
+    extra_vars: dict | None = None,
     event_handler: Callable[[dict[str, Any]], bool] | None = None,
 ) -> ansible_runner.Runner:
     """
     Wraps ansible_runner.run to run Ansible tasks with some defaults for
     Boardwalk
     """
+    extra_vars = extra_vars if extra_vars is not None else {}
     workspace = boardwalk.manifest.get_ws()
 
     runner_kwargs: RunnerKwargs = {

--- a/src/boardwalk/cli.py
+++ b/src/boardwalk/cli.py
@@ -10,7 +10,7 @@ from importlib.metadata import version as lib_version
 from typing import TYPE_CHECKING
 
 import click
-from loguru import logger  # noqa: F401
+from loguru import logger
 
 from boardwalk.app_exceptions import BoardwalkException
 from boardwalk.cli_catch import catch, release

--- a/src/boardwalk/cli_init.py
+++ b/src/boardwalk/cli_init.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
     class runnerKwargs(TypedDict, total=False):
         gather_facts: bool
         hosts: str
-        hosts: str
         invocation_msg: str
         limit: str
         tasks: AnsibleTasksType
@@ -87,7 +86,7 @@ def init(ctx: click.Context, limit: str, retry: bool):
     if retry:
         if not retry_file_path.exists():
             raise BoardwalkException("No retry file exists")
-        runner_kwargs["limit"] = f"@{str(retry_file_path)}"
+        runner_kwargs["limit"] = f"@{retry_file_path!s}"
 
     # Save the host pattern we are initializing with. If the pattern changes after
     # this point, other operations will need the state reset and init to be re-done

--- a/src/boardwalk/cli_run.py
+++ b/src/boardwalk/cli_run.py
@@ -885,7 +885,7 @@ def execute_workflow_jobs(host: Host, workspace: Workspace, job_kind: str, verbo
     elif job_kind == "exit":
         jobs = workflow.i_exit_jobs
     else:
-        raise Exception
+        raise BoardwalkException(f"{job_kind} is not a supported job type")
     if len(jobs) == 0:
         return
     logger.info(f"{host.name}: Running workflow {job_kind} jobs")

--- a/src/boardwalk/cli_workspace.py
+++ b/src/boardwalk/cli_workspace.py
@@ -143,7 +143,7 @@ def workspace_list(jobs: bool = False, config: bool = False, workspace: str | No
             workspace_config: WorkspaceConfig = workspace_class_instance.config()
 
             # Process the workflow data
-            workflow: Workflow = getattr(workspace_config, "workflow")
+            workflow: Workflow = workspace_config.workflow
 
             workspace_configuration_detail_table = Table(show_header=False, box=None)
 

--- a/src/boardwalk/host.py
+++ b/src/boardwalk/host.py
@@ -50,7 +50,7 @@ class Host(BaseModel, extra="forbid"):
         check: bool = False,
         gather_facts: bool = True,
         quiet: bool = True,
-        extra_vars: dict = {},
+        extra_vars: dict | None = None,
         event_handler: Callable[[dict[str, Any]], bool] | None = None,
     ) -> Runner:
         """
@@ -67,7 +67,7 @@ class Host(BaseModel, extra="forbid"):
             check=check,
             gather_facts=gather_facts,
             quiet=quiet,
-            extra_vars=extra_vars,
+            extra_vars=extra_vars if extra_vars is not None else {},
             event_handler=event_handler,
         )
 

--- a/src/boardwalk/manifest.py
+++ b/src/boardwalk/manifest.py
@@ -84,7 +84,7 @@ def get_ws() -> Workspace:
 
     # If somehow the active workspace name did not get set, we panic
     if not active_workspace_name:
-        raise Exception("active_workspace_name is not set but it should have been")
+        raise BoardwalkException("active_workspace_name is not set but it should have been")
 
     # Ensure the active Workspace name actually exists.
     if Workspace.exists(active_workspace_name):
@@ -118,15 +118,15 @@ class BaseJob:
     The base class for Jobs
     """
 
-    def __init__(self, options: dict[str, Any] = dict()):
+    def __init__(self, options: dict[str, Any]):
         self.name = self.__class__.__name__
         self._check_options(options)
-        self.options = options
+        self.options = options if options is not None else {}
         """Optional dict of options that can be leveraged inside the class"""
 
     def required_options(self) -> tuple[str]:
         """Optional user method. Defines any required Job input options"""
-        return tuple()  # type: ignore
+        return ()  # type: ignore
 
     def preconditions(self, facts: AnsibleFacts, inventory_vars: InventoryHostVars) -> bool:
         """Optional user method. Return True if preconditions are met, else return False"""
@@ -157,8 +157,9 @@ class BaseJob:
 class TaskJob(BaseJob):
     """Defines a single Job as methods, used to execute Tasks"""
 
-    def __init__(self, options: dict[str, Any] = dict()):
-        super().__init__(options=options)
+    def __init__(self, options: dict[str, Any] | None = None):
+        _options = options if options is not None else {}
+        super().__init__(options=_options)
         self.job_type = JobTypes.TASK
 
     def tasks(self) -> AnsibleTasksType:
@@ -174,19 +175,21 @@ class Job(TaskJob):
     Deprecated in favor of TaskJob.
     """
 
-    def __init__(self, options: dict[str, Any] = dict()):
+    def __init__(self, options: dict[str, Any] | None = None):
+        _options = options if options is not None else {}
         warnings.warn(
             "The job type Job is deprecated, and will be removed in a future release. Use TaskJob or PlaybookJob, as appropriate.",
             DeprecationWarning,
         )
-        super().__init__(options=options)
+        super().__init__(options=_options)
 
 
 class PlaybookJob(BaseJob):
     """Defines a single Job as methods, used to execute Playbooks"""
 
-    def __init__(self, options: dict[str, Any] = dict()):
-        super().__init__(options=options)
+    def __init__(self, options: dict[str, Any] | None = None):
+        _options = options if options is not None else {}
+        super().__init__(options=_options)
         self.job_type = JobTypes.PLAYBOOK
         self.extra_vars = options
 
@@ -225,10 +228,10 @@ class Workflow(ABC):
     def __init__(self):
         # If user-provided Jobs as a single Job, convert to tuple
         workflow_jobs = self.jobs()
-        if isinstance(workflow_jobs, TaskJob) or isinstance(workflow_jobs, PlaybookJob):
+        if isinstance(workflow_jobs, (TaskJob, PlaybookJob)):
             workflow_jobs = (workflow_jobs,)
         workflow_exit_jobs = self.exit_jobs()
-        if isinstance(workflow_exit_jobs, TaskJob) or isinstance(workflow_exit_jobs, PlaybookJob):
+        if isinstance(workflow_exit_jobs, (TaskJob, PlaybookJob)):
             workflow_exit_jobs = (workflow_exit_jobs,)
         # self._jobs is the list of initialized Jobs.
         self.i_jobs = workflow_jobs
@@ -285,7 +288,7 @@ class WorkspaceConfig:
     :param workflow: The workflow the workspace uses
     """
 
-    valid_sort_orders = ["ascending", "descending", "shuffle"]
+    valid_sort_orders: frozenset[str] = frozenset(["ascending", "descending", "shuffle"])
 
     def __init__(
         self,
@@ -376,11 +379,12 @@ class Workspace(ABC):
         """Flush workspace state to disk"""
         # The statefile is first written to a temp file so that failures in flushing
         # will not corrupt an existing statefile
-        tf = NamedTemporaryFile(mode="wb", delete=False, dir=self.path, prefix="statefile.json.").name
-        with open(tf, mode="w") as fd:
+        with open(
+            NamedTemporaryFile(mode="wb", delete=False, dir=self.path, prefix="statefile.json.").name, mode="w"
+        ) as fd:
             q = self.state.model_dump_json()
             fd.write(q)
-        os.rename(src=tf, dst=self.path.joinpath("statefile.json"))
+        os.rename(src=fd.name, dst=self.path.joinpath("statefile.json"))
 
     def reset(self):
         """Resets active workspace. Configuration is retained but other state is lost"""
@@ -459,9 +463,7 @@ class Workspace(ABC):
         workspace_names: list[str] = []
         for workspace in Workspace.__subclasses__():
             workspace_names.append(workspace.__qualname__)
-        if name in workspace_names:
-            return True
-        return False
+        return name in workspace_names
 
     @staticmethod
     def fetch_subclass(name: str) -> Callable[..., Workspace]:

--- a/src/boardwalkd/cli.py
+++ b/src/boardwalkd/cli.py
@@ -20,9 +20,9 @@ from boardwalkd.slack_error_advice import SlackErrorAdviceConfigError, parse_sla
 from boardwalkd.snapshot import load_inventory_context
 from boardwalkd.snapshot import sanitize_status_snapshot as sanitize_status_snapshot_data
 
-CONTEXT_SETTINGS: dict = dict(
-    auto_envvar_prefix="BOARDWALKD",
-)
+CONTEXT_SETTINGS: dict = {
+    "auto_envvar_prefix": "BOARDWALKD",
+}
 
 
 @click.group()
@@ -33,7 +33,6 @@ def cli():
 
     To see more info about any subcommand, execute `boardwalkd <subcommand> --help`
     """
-    pass
 
 
 @cli.command(context_settings=CONTEXT_SETTINGS)

--- a/src/boardwalkd/protocol.py
+++ b/src/boardwalkd/protocol.py
@@ -248,8 +248,8 @@ class Client:
             if e.code == 421:
                 # The server URL is probably incorrect
                 raise ConnectionRefusedError
-            else:
-                raise e
+            else:  # Reraise
+                raise
 
     def workspace_delete_mutex(self, workspace_name: str):
         """Deletes a workspace mutex"""
@@ -261,8 +261,8 @@ class Client:
         except HTTPError as e:
             if e.code == 404:
                 raise WorkspaceNotFound
-            else:
-                raise e
+            else:  # Reraise
+                raise
 
     def workspace_get_details(self, workspace_name: str) -> WorkspaceDetails:
         """Queries the server for workspace details"""
@@ -273,8 +273,8 @@ class Client:
         except HTTPError as e:
             if e.code == 404:
                 raise WorkspaceNotFound
-            else:
-                raise e
+            else:  # Reraise
+                raise
 
         details = WorkspaceDetails()
         return details.model_validate_json(request.body)
@@ -290,8 +290,8 @@ class Client:
         except HTTPError as e:
             if e.code == 404:
                 raise WorkspaceNotFound
-            else:
-                raise e
+            else:  # Reraise
+                raise
 
     def workspace_post_clear_remote_state_request(self, workspace_name: str):
         """Requests that a worker remove the host's remote Boardwalk state fact."""
@@ -304,8 +304,8 @@ class Client:
         except HTTPError as e:
             if e.code == 404:
                 raise WorkspaceNotFound
-            else:
-                raise e
+            else:  # Reraise
+                raise
 
     def workspace_post_clear_remote_mutex_request(self, workspace_name: str):
         """Requests that a worker remove the host's remote Boardwalk mutex."""
@@ -318,8 +318,8 @@ class Client:
         except HTTPError as e:
             if e.code == 404:
                 raise WorkspaceNotFound
-            else:
-                raise e
+            else:  # Reraise
+                raise
 
     def workspace_delete_clear_remote_mutex_request(self, workspace_name: str):
         """Clears a pending remote mutex cleanup request."""
@@ -331,8 +331,8 @@ class Client:
         except HTTPError as e:
             if e.code == 404:
                 raise WorkspaceNotFound
-            else:
-                raise e
+            else:  # Reraise
+                raise
 
     def workspace_delete_clear_remote_state_request(self, workspace_name: str):
         """Clears a pending remote state cleanup request."""
@@ -344,8 +344,8 @@ class Client:
         except HTTPError as e:
             if e.code == 404:
                 raise WorkspaceNotFound
-            else:
-                raise e
+            else:  # Reraise
+                raise
 
     def workspace_post_details(self, workspace_name: str, workspace_details: WorkspaceDetails):
         """Updates the workspace details at the server"""
@@ -358,8 +358,8 @@ class Client:
         except HTTPError as e:
             if e.code == 404:
                 raise WorkspaceNotFound
-            else:
-                raise e
+            else:  # Reraise
+                raise
 
     def workspace_post_heartbeat(self, workspace_name: str):
         """Posts a heartbeat to the server. This method will not automatically
@@ -374,8 +374,8 @@ class Client:
         except HTTPError as e:
             if e.code == 404:
                 raise WorkspaceNotFound
-            else:
-                raise e
+            else:  # Reraise
+                raise
 
     def workspace_heartbeat_keepalive(self, workspace_name: str, quit: threading.Event) -> None:
         """Tries to post a heartbeat to the server every 5 seconds"""
@@ -393,7 +393,6 @@ class Client:
                 socket.gaierror,
             ) as e:
                 logger.debug(f"Heartbeat keepalive error {e.__class__.__qualname__}")
-                pass
             time.sleep(5)  # nosemgrep: python.lang.best-practice.sleep.arbitrary-sleep
 
     def workspace_heartbeat_keepalive_connect(self, workspace_name: str) -> threading.Event:
@@ -425,8 +424,8 @@ class Client:
         except HTTPError as e:
             if e.code == 404:
                 raise WorkspaceNotFound
-            else:
-                raise e
+            else:  # Reraise
+                raise
 
     def workspace_queue_event(
         self,
@@ -472,8 +471,8 @@ class Client:
                 raise WorkspaceNotFound
             if e.code == 409:
                 raise WorkspaceHasMutex
-            else:
-                raise e
+            else:  # Reraise
+                raise
 
     def workspace_get_semaphores(self, workspace_name: str) -> WorkspaceSemaphores:
         """Queries the server for workspace semaphores"""
@@ -482,8 +481,8 @@ class Client:
         except HTTPError as e:
             if e.code == 404:
                 raise WorkspaceNotFound
-            else:
-                raise e
+            else:  # Reraise
+                raise
 
         semaphores = WorkspaceSemaphores()
         return semaphores.parse_raw(request.body)

--- a/src/boardwalkd/server.py
+++ b/src/boardwalkd/server.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from importlib.metadata import version as lib_version
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 from urllib.parse import ParseResult, urljoin, urlparse
 
 import tornado.auth
@@ -225,7 +225,7 @@ def ui_method_sort_events_by_date(handler: UIBaseHandler, events: deque[Workspac
     sorts them by datetime in ascending order"""
     # While we assume UTC--and the code did/does--this allows for backward compatibility
     # with older `boardwalk` client versions
-    key: Callable[[WorkspaceEvent], datetime] = lambda x: x.create_time.replace(tzinfo=UTC)  # type: ignore # noqa: E731
+    key: Callable[[WorkspaceEvent], datetime] = lambda x: x.create_time.replace(tzinfo=UTC)  # type: ignore
     return sorted(events, key=key, reverse=True)
 
 
@@ -756,7 +756,6 @@ class APIBaseHandler(tornado.web.RequestHandler):
 
     def check_xsrf_cookie(self):
         """We ignore this method on API requests"""
-        pass
 
     def get_current_user(self) -> bytes | None:
         """Decodes the API token to return the current logged in user."""
@@ -801,7 +800,7 @@ async def notify_auth_login(login_url: str, auth_context: dict[str, str | None],
                 server_url=settings["url"].geturl(),
                 slack_user_mention=slack_user_mention,
             )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 -- Not quite sure what errors the AsyncWebhookClient could generate, so this is fine to silence.
         logger.error(f"Could not send auth login Slack notification: {e}")
 
 
@@ -840,7 +839,7 @@ class AuthLoginApiHandler(UIBaseHandler):
 class AuthLoginApiWebsocketHandler(tornado.websocket.WebSocketHandler):
     """Socket used by CLI clients to login to the API and get an auth token"""
 
-    clients: dict[AuthLoginApiWebsocketHandler, str] = {}
+    clients: ClassVar[dict[AuthLoginApiWebsocketHandler, str]] = {}
 
     def open(self):
         def id_client() -> str:
@@ -1162,26 +1161,23 @@ class WorkspaceEventApiHandler(APIBaseHandler):
 
         app_log.info(f"worker_event: {self.request.remote_ip} {workspace} {event.severity} {event.message}")
 
-        if broadcast:
-            if self.settings["slack_webhook_url"] or self.settings["slack_error_webhook_url"]:
-                workspace_details = state.workspaces[workspace].details
-                slack_user_mention = None
-                if event.severity == "error":
-                    if workspace_details.deployment_user_email:
-                        slack_user_mention = state.users[
-                            workspace_details.deployment_user_email
-                        ].slack_cache.user_mention
-                    else:
-                        slack_user_mention = None
-                await handle_slack_broadcast(
-                    event,
-                    workspace,
-                    self.settings["slack_webhook_url"],
-                    self.settings["slack_error_webhook_url"],
-                    self.settings["url"].geturl(),
-                    error_advice=matching_error_advice(event, self.settings["slack_error_advice_rules"]),
-                    slack_user_mention=slack_user_mention,
-                )
+        if broadcast and (self.settings["slack_webhook_url"] or self.settings["slack_error_webhook_url"]):
+            workspace_details = state.workspaces[workspace].details
+            slack_user_mention = None
+            if event.severity == "error":
+                if workspace_details.deployment_user_email:
+                    slack_user_mention = state.users[workspace_details.deployment_user_email].slack_cache.user_mention
+                else:
+                    slack_user_mention = None
+            await handle_slack_broadcast(
+                event,
+                workspace,
+                self.settings["slack_webhook_url"],
+                self.settings["slack_error_webhook_url"],
+                self.settings["url"].geturl(),
+                error_advice=matching_error_advice(event, self.settings["slack_error_advice_rules"]),
+                slack_user_mention=slack_user_mention,
+            )
 
         state.flush()
 
@@ -1476,7 +1472,6 @@ async def run(
     jenkins_job_url: str = "",
 ) -> tuple[tornado.web.Application, list[HTTPServer]]:
     """Starts the tornado server and IO loop"""
-    global state
     global SLACK_SLASH_COMMAND_PREFIX
 
     app = make_app(

--- a/src/boardwalkd/slack.py
+++ b/src/boardwalkd/slack.py
@@ -74,12 +74,11 @@ async def update_cached_slack_data(limit: int = 200, cursor: str | None = None) 
             next_cursor = resp.get("response_metadata", {}).get("next_cursor")
             should_flush_state = False
             for member in resp.get("members", {}):
-                if email := member.get("profile", {}).get("email"):
-                    if email in STATE.users:
-                        logger.debug(f"Updating cached Slack data for {email}")
-                        STATE.users[email].slack_cache.user_id = member.get("id")
-                        STATE.users[email].slack_cache.real_name = member.get("profile", {}).get("real_name", "Unknown")
-                        should_flush_state = True
+                if (email := member.get("profile", {}).get("email")) and email in STATE.users:
+                    logger.debug(f"Updating cached Slack data for {email}")
+                    STATE.users[email].slack_cache.user_id = member.get("id")
+                    STATE.users[email].slack_cache.real_name = member.get("profile", {}).get("real_name", "Unknown")
+                    should_flush_state = True
             if should_flush_state:
                 STATE.flush()
             if next_cursor:
@@ -220,13 +219,10 @@ async def catch_release_workspaces(ack: AsyncAck, body: dict[str, Any], client: 
             DividerBlock(),
             SectionBlock(
                 text=MarkdownTextObject(
-                    text=" ".join(  # semgrep avoidance https://sg.run/Kl07 -- string-concat-in-list
-                        [
-                            "*Note*: It should go without saying that you should exercise caution prior to catching or",
-                            "releasing workspaces. Dragons might be lurking. 🐉",
-                        ]
-                    ),
-                )
+                    # nosemgrep: python.lang.correctness.common-mistakes.string-concat-in-list.string-concat-in-list
+                    text="*Note*: It should go without saying that you should exercise caution prior "
+                    "to catching or releasing workspaces. Dragons might be lurking. 🐉"
+                ),
             ),
         ],
     )
@@ -262,7 +258,7 @@ async def modal_catch_release_view_submission_event(
     _actioned_workspaces: list[str] = []
     for workspace in workspaces:
         if workspace not in rejected_workspaces:
-            STATE.workspaces[workspace].semaphores.caught = True if action == "catch" else False
+            STATE.workspaces[workspace].semaphores.caught = bool(action == "catch")
             # Record who caught the workspace(s)
             event = WorkspaceEvent(
                 severity="info",
@@ -328,7 +324,7 @@ async def modal_catch_release_view_submission_event(
                 text=f"Workspace(s) {action} successfully!",
             )
         else:  # Reraise.
-            raise e
+            raise
 
 
 @app.command(f"/{SLACK_SLASH_COMMAND_PREFIX}-list")

--- a/src/boardwalkd/slack_error_advice.py
+++ b/src/boardwalkd/slack_error_advice.py
@@ -9,7 +9,7 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
-from pydantic import PrivateAttr, ValidationError, field_validator
+from pydantic import Field, PrivateAttr, ValidationError, field_validator
 
 from boardwalkd.protocol import ProtocolBaseModel, WorkspaceEvent
 
@@ -34,7 +34,7 @@ class SlackErrorAdviceRule(ProtocolBaseModel):
                 raise ValueError(f"Invalid regex pattern {pattern!r}: {e}") from e
         return patterns
 
-    def model_post_init(self, __context: Any) -> None:
+    def model_post_init(self, context: Any, /) -> None:
         self._compiled_patterns = [re.compile(pattern, flags=REGEX_FLAGS) for pattern in self.patterns]
 
     def matches(self, event_message: str) -> bool:
@@ -44,7 +44,7 @@ class SlackErrorAdviceRule(ProtocolBaseModel):
 class SlackErrorAdviceConfig(ProtocolBaseModel):
     """Top-level Slack advice configuration."""
 
-    rules: list[SlackErrorAdviceRule] = []
+    rules: list[SlackErrorAdviceRule] = Field([])
 
 
 class SlackErrorAdviceConfigError(ValueError):

--- a/src/boardwalkd/snapshot.py
+++ b/src/boardwalkd/snapshot.py
@@ -90,7 +90,7 @@ def _inventory_labels_for_pattern(pattern: Any, inventory: Mapping[str, Any] | N
     labels: set[str] = set()
     for raw_part in str(pattern).split(":"):
         part = raw_part.strip()
-        if not part or part.startswith("!") or part.startswith("&"):
+        if not part or part.startswith(("!", "&")):
             continue
         labels.update(_inventory_labels_for_group(part, parents))
     return labels

--- a/src/boardwalkd/state.py
+++ b/src/boardwalkd/state.py
@@ -29,7 +29,7 @@ class CachedSlackData(StateBaseModel):
     user_id: str | None = None
     real_name: str | None = None
 
-    @computed_field(exclude_if=lambda v: 1 == 1)
+    @computed_field(exclude_if=lambda v: True)
     @property
     def user_mention(self) -> str | None:
         """Property that returns the user-mention string for this :class:`User`.

--- a/src/boardwalkd/utils.py
+++ b/src/boardwalkd/utils.py
@@ -42,9 +42,7 @@ def list_inactive_workspaces(last_seen_seconds: int = 10) -> list[str]:
     connected worker was seen before the workspace is considered inactive.
     Defaults to 10.
     """
-    return sorted(
-        [name for name in server.state.workspaces.keys() if name not in list_active_workspaces(last_seen_seconds)]
-    )
+    return sorted([name for name in server.state.workspaces if name not in list_active_workspaces(last_seen_seconds)])
 
 
 def count_of_workspaces_caught() -> int:

--- a/test/boardwalk/test_cli_workspace.py
+++ b/test/boardwalk/test_cli_workspace.py
@@ -63,16 +63,12 @@ def test_workspace_list_alerts_if_class_abstract(
     assert result.exit_code == 0
     if warning_on_stderr_expected:
         assert any(
-            [
-                f"Workspace {command_arguments[2]} seems to be sourced from abc.py." in message
-                for message in caplog.messages
-            ]
+            f"Workspace {command_arguments[2]} seems to be sourced from abc.py." in message
+            for message in caplog.messages
         )
         assert any(
-            [
-                "One or more classes couldn't have their exact source module identified" in message
-                for message in caplog.messages
-            ]
+            "One or more classes couldn't have their exact source module identified" in message
+            for message in caplog.messages
         )
     else:
         assert len(caplog.messages) == 0

--- a/test/boardwalk/test_manifest.py
+++ b/test/boardwalk/test_manifest.py
@@ -33,6 +33,80 @@ def test_verify_job_types_match_expected_types(job_class, job_type):
     assert job_type == job.job_type
 
 
+@pytest.mark.filterwarnings("ignore:The job type Job is deprecated")
+@pytest.mark.parametrize(
+    ("job_class"),
+    [
+        pytest.param(TaskJob),
+        pytest.param(PlaybookJob),
+        pytest.param(Job),
+    ],
+)
+def test_jobs_definining_options_have_options_existing_in_instantiated_class(job_class) -> None:
+    test_options = {"option_one": 123, "option_omega": "xyz"}
+
+    class TestJobClass(job_class):
+        pass
+
+    obj = TestJobClass(options=test_options)
+    assert obj.options == test_options
+
+
+@pytest.mark.filterwarnings("ignore:The job type Job is deprecated")
+@pytest.mark.parametrize(
+    ("job_class"),
+    [
+        pytest.param(TaskJob),
+        pytest.param(PlaybookJob),
+        pytest.param(Job),
+    ],
+)
+@pytest.mark.parametrize(
+    ("required_options_tuple", "options_provided", "expected_missing_options"),
+    [
+        pytest.param(("required_one",), ("some_different_option",), ("required_one",)),
+        pytest.param(("required_one", "required_two"), ("required_one",), ("required_two",)),
+        pytest.param(
+            ("required_one", "required_two", "required_three"), ("required_one", "required_two"), ("required_three",)
+        ),
+    ],
+)
+def test_jobs_definining_required_options_raise_when_options_not_provided(
+    job_class, required_options_tuple: tuple[str], options_provided: tuple[str], expected_missing_options: tuple[str]
+) -> None:
+    test_options = {k: "some_value" for k in options_provided}
+
+    class TestJobClass(job_class):
+        def required_options(self) -> tuple[str, ...]:
+            return required_options_tuple
+
+    with pytest.raises(ValueError) as err:
+        _obj = TestJobClass(options=test_options)
+
+    for missing_option in expected_missing_options:
+        assert missing_option in str(err)
+
+
+@pytest.mark.filterwarnings("ignore:The job type Job is deprecated")
+@pytest.mark.parametrize(
+    ("job_class"),
+    [
+        pytest.param(TaskJob),
+        pytest.param(PlaybookJob),
+        pytest.param(Job),
+    ],
+)
+def test_jobs_definining_required_options_instantiates_correctly_when_provided(job_class) -> None:
+    test_options = {"required_option": "value", "optional_option": "some_other_value"}
+
+    class TestJobClass(job_class):
+        def required_options(self) -> tuple[str, ...]:
+            return ("required_option",)
+
+    obj = TestJobClass(options=test_options)
+    assert obj.options == test_options
+
+
 @pytest.mark.parametrize(
     ("job_class", "function_name"),
     [
@@ -49,15 +123,14 @@ def test_verify_job_classes_have_expected_task_functions(job_class, function_nam
 
 
 def test_using_not_differentiated_Job_class_warns_about_deprecation():
+    class TestJob(Job):
+        def tasks(self):
+            return [{"ansible.builtin.debug": {"msg": "Hello, Boardwalk!"}}]
+
     with pytest.warns(
         DeprecationWarning,
         match="The job type Job is deprecated, and will be removed in a future release. Use TaskJob or PlaybookJob, as appropriate.",
     ):
-
-        class TestJob(Job):
-            def tasks(self):
-                return [{"ansible.builtin.debug": {"msg": "Hello, Boardwalk!"}}]
-
         TestJob()
 
 

--- a/test/boardwalk/test_utils.py
+++ b/test/boardwalk/test_utils.py
@@ -12,7 +12,6 @@ from boardwalk.utils import strtobool
         ("True", True),
         ("t", True),
         ("true", True),
-        ("True", True),
         ("On", True),
         ("on", True),
         ("1", True),

--- a/test/boardwalkd/test_auth_prompts.py
+++ b/test/boardwalkd/test_auth_prompts.py
@@ -15,7 +15,7 @@ from boardwalkd.auth_prompts import AuthLoginPrompt
 def test_AuthLoginPrompt_accepts_deployment_url_with_valid_scheme(url: str):
     """We expect that any valid deployment_url in the auth_context is present from an instantiated :class:`AuthLoginPrompt`"""
     auth_login_prompt = AuthLoginPrompt(
-        client_id="123", login_url="https://foobar.example", auth_context=dict({"deployment_url": url})
+        client_id="123", login_url="https://foobar.example", auth_context={"deployment_url": url}
     )
     assert auth_login_prompt.auth_context["deployment_url"] == url
 
@@ -31,9 +31,7 @@ def test_AuthLoginPrompt_accepts_deployment_url_with_valid_scheme(url: str):
 def test_AuthLoginPrompt_raises_when_invalid_url_scheme_provided(url: str):
     """We expect that any invalid schema in the auth_context's deployment_url is rejected with a Pydantic validation error"""
     with pytest.raises(ValidationError) as exc_info:
-        _ = AuthLoginPrompt(
-            client_id="123", login_url="https://foobar.example", auth_context=dict({"deployment_url": url})
-        )
+        _ = AuthLoginPrompt(client_id="123", login_url="https://foobar.example", auth_context={"deployment_url": url})
     errors = exc_info.value.errors()
     assert len(errors) == 1
     assert errors[0]["type"] == "invalid_AuthLoginPrompt_deployment_url_scheme"

--- a/test/boardwalkd/test_boardwalkd_cli.py
+++ b/test/boardwalkd/test_boardwalkd_cli.py
@@ -44,14 +44,13 @@ def test_version():
         (
             "Missing required parameters to serve boardwalkd: --port/--tls-port",
             [r'--host-header-pattern="(localhost|127\.0\.0\.1)"', '--url="http://localhost:8888"'],
-            2,
+            1,
         ),  # type: ignore
     ],
 )
-async def test_incomplete_serve_command(
-    msg: str, options: list[str], expected_rc: int, command: list[str] = ["boardwalkd", "serve"]
-):
+async def test_incomplete_serve_command(msg: str, options: list[str], expected_rc: int):
     """Running `boardwalkd serve` without the required parameters shouldn't succeed."""
+    command: list[str] = ["boardwalkd", "serve"]
     command.extend(options)
     async with create_task_group():
         with fail_after(delay=10) as scope:
@@ -106,7 +105,8 @@ def test_serve_passes_demo_to_server_run():
 def test_serve_passes_develop_snapshot_to_server_run():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        open("snapshot.json", "w").write('{"workspaces": []}')
+        with open("snapshot.json", "w") as fd:
+            fd.write('{"workspaces": []}')
         result, run_mock = invoke_serve_with_run_mock(
             [
                 "--develop",
@@ -126,7 +126,8 @@ def test_serve_passes_develop_snapshot_to_server_run():
 def test_serve_rejects_develop_snapshot_without_develop():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        open("snapshot.json", "w").write('{"workspaces": []}')
+        with open("snapshot.json", "w") as fd:
+            fd.write('{"workspaces": []}')
         result = runner.invoke(
             cli=cli.serve,
             args=[
@@ -144,7 +145,8 @@ def test_serve_rejects_develop_snapshot_without_develop():
 def test_serve_rejects_demo_with_develop_snapshot():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        open("snapshot.json", "w").write('{"workspaces": []}')
+        with open("snapshot.json", "w") as fd:
+            fd.write('{"workspaces": []}')
         result = runner.invoke(
             cli=cli.serve,
             args=[
@@ -164,30 +166,30 @@ def test_serve_rejects_demo_with_develop_snapshot():
 def test_sanitize_status_snapshot_command_writes_redacted_snapshot():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        open("raw.json", "w").write(
-            """
+        with open("raw.json", "w") as fd:
+            fd.write("""
             {
-              "workspaces": [{
-                "name": "real_workspace",
-                "semaphores": {"caught": true, "has_mutex": true},
-                "details": {
-                  "current_host": "node-alpha-a",
-                  "ui_group": "alpha",
-                  "worker_hostname": "worker-prod-01",
-                  "worker_username": "operator-a",
-                  "worker_connected": true
-                },
-                "last_seen": "2026-06-03T00:00:00+00:00"
-              }]
+                "workspaces": [{
+                    "name": "real_workspace",
+                    "semaphores": {"caught": true, "has_mutex": true},
+                    "details": {
+                        "current_host": "node-alpha-a",
+                        "ui_group": "alpha",
+                        "worker_hostname": "worker-prod-01",
+                        "worker_username": "operator-a",
+                        "worker_connected": true
+                    },
+                    "last_seen": "2026-06-03T00:00:00+00:00"
+                }]
             }
-            """
-        )
+            """)
 
         result = runner.invoke(
             cli=cli.sanitize_status_snapshot,
             args=["raw.json", "sanitized.json", "--captured-at=2026-06-03T00:00:03+00:00"],
         )
-        text = open("sanitized.json").read()
+        with open("sanitized.json") as fd:
+            text = fd.read()
 
     assert result.exit_code == 0
     assert "snapshot_alpha_001" in text
@@ -201,24 +203,23 @@ def test_sanitize_status_snapshot_command_writes_redacted_snapshot():
 def test_sanitize_status_snapshot_command_can_preserve_identifiers_for_private_replay():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        open("raw.json", "w").write(
-            """
+        with open("raw.json", "w") as fd:
+            fd.write("""
             {
-              "workspaces": [{
-                "name": "real_workspace",
-                "semaphores": {"caught": true, "has_mutex": true},
-                "details": {
-                  "current_host": "node-alpha-a",
-                  "host_pattern": "nodes_alpha",
-                  "worker_hostname": "worker-prod-01",
-                  "worker_username": "operator-a",
-                  "worker_connected": true
-                },
-                "last_seen": "2026-06-03T00:00:00+00:00"
-              }]
+                "workspaces": [{
+                    "name": "real_workspace",
+                    "semaphores": {"caught": true, "has_mutex": true},
+                    "details": {
+                        "current_host": "node-alpha-a",
+                        "host_pattern": "nodes_alpha",
+                        "worker_hostname": "worker-prod-01",
+                        "worker_username": "operator-a",
+                        "worker_connected": true
+                    },
+                    "last_seen": "2026-06-03T00:00:00+00:00"
+                }]
             }
-            """
-        )
+            """)
 
         result = runner.invoke(
             cli=cli.sanitize_status_snapshot,
@@ -229,7 +230,8 @@ def test_sanitize_status_snapshot_command_can_preserve_identifiers_for_private_r
                 "--preserve-identifiers",
             ],
         )
-        text = open("private-replay.json").read()
+        with open("private-replay.json") as fd:
+            text = fd.read()
 
     assert result.exit_code == 0
     assert "real_workspace" in text
@@ -242,30 +244,28 @@ def test_sanitize_status_snapshot_command_can_preserve_identifiers_for_private_r
 def test_sanitize_status_snapshot_command_can_enrich_groups_from_inventory_json():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        open("raw.json", "w").write(
-            """
+        with open("raw.json", "w") as fd:
+            fd.write("""
             {
-              "workspaces": [{
-                "name": "storage_workspace",
-                "semaphores": {"caught": true, "has_mutex": true},
-                "details": {
-                  "host_pattern": "storage_001:!storage_nonprod",
-                  "worker_connected": true
-                },
-                "last_seen": "2026-06-03T00:00:00+00:00"
-              }]
+                "workspaces": [{
+                    "name": "storage_workspace",
+                    "semaphores": {"caught": true, "has_mutex": true},
+                    "details": {
+                        "host_pattern": "storage_001:!storage_nonprod",
+                        "worker_connected": true
+                    },
+                    "last_seen": "2026-06-03T00:00:00+00:00"
+                }]
             }
-            """
-        )
-        open("inventory.json", "w").write(
-            """
+            """)
+        with open("inventory.json", "w") as fd:
+            fd.write("""
             {
-              "_meta": {"hostvars": {}},
-              "storage_001": {"hosts": ["node-alpha-a"]},
-              "storage_alpha": {"children": ["storage_001"]}
+                "_meta": {"hostvars": {}},
+                "storage_001": {"hosts": ["node-alpha-a"]},
+                "storage_alpha": {"children": ["storage_001"]}
             }
-            """
-        )
+            """)
 
         result = runner.invoke(
             cli=cli.sanitize_status_snapshot,
@@ -277,7 +277,8 @@ def test_sanitize_status_snapshot_command_can_enrich_groups_from_inventory_json(
                 "--inventory-json=inventory.json",
             ],
         )
-        text = open("private-replay.json").read()
+        with open("private-replay.json") as fd:
+            text = fd.read()
 
     assert result.exit_code == 0
     assert "storage_workspace" in text

--- a/test/boardwalkd/test_broadcast.py
+++ b/test/boardwalkd/test_broadcast.py
@@ -1,6 +1,6 @@
 import pytest
 
-import boardwalkd.broadcast as broadcast
+from boardwalkd import broadcast
 from boardwalkd.broadcast import handle_auth_login_broadcast
 
 

--- a/test/boardwalkd/test_snapshot.py
+++ b/test/boardwalkd/test_snapshot.py
@@ -2,7 +2,7 @@ import json
 import re
 from datetime import UTC, datetime, timedelta
 
-import boardwalkd.server as server
+from boardwalkd import server
 from boardwalkd.dashboard import DashboardFilters, build_dashboard
 from boardwalkd.snapshot import load_inventory_context, sanitize_status_snapshot, seed_snapshot_workspaces
 from boardwalkd.state import State, WorkspaceState

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -76,7 +76,7 @@ async def spawn_boardwalkd_server(anyio_backend, free_tcp_port: int):
             "url": url,
             "workspace_status_json": True,
         }
-        app, http_servers = await boardwalkd_run(**run_kwargs)
+        _app, http_servers = await boardwalkd_run(**run_kwargs)
 
         await asyncio.sleep(0.5)
 

--- a/test/server-client/Boardwalkfile.py
+++ b/test/server-client/Boardwalkfile.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
-from pylib.dynamically_constructed_workspaces import *  # noqa: F403
-from pylib.regression_bz_svreng_609 import *  # noqa: F403
-from pylib.remote_state_set_unsuccessful_during_active_workflow import *  # noqa: F403
+from pylib.dynamically_constructed_workspaces import *
+from pylib.regression_bz_svreng_609 import *
+from pylib.remote_state_set_unsuccessful_during_active_workflow import *
 
 from boardwalk import PlaybookJob, TaskJob, Workflow, Workspace, WorkspaceConfig, path
 

--- a/test/server-client/pylib/regression_bz_svreng_609.py
+++ b/test/server-client/pylib/regression_bz_svreng_609.py
@@ -119,10 +119,10 @@ from boardwalk import Job, PlaybookJob, TaskJob, Workflow, Workspace, WorkspaceC
 zabbix_api_token = "NotARealToken"
 
 __all__ = [
-    "TaskJobWithOptionsShouldSucceedWorkspace",
     "PlaybookJobWithOptionsShouldSucceedWorkspace",
-    "TaskJobWithPreconditionsShouldSucceedIfHostIsMacOSXWorkspace",
+    "TaskJobWithOptionsShouldSucceedWorkspace",
     "TaskJobWithPreconditionsShouldBeSkippedIfHostIsMacOSXWorkspace",
+    "TaskJobWithPreconditionsShouldSucceedIfHostIsMacOSXWorkspace",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -354,7 +354,7 @@ dev = [
     { name = "anyio", specifier = ">=4.7.0,<5" },
     { name = "pyright", specifier = ">=1.1.350" },
     { name = "pytest", specifier = ">=9.0.3,<10" },
-    { name = "ruff", specifier = ">=0.11.13,<0.12" },
+    { name = "ruff", specifier = ">=0.16.0,<0.17" },
 ]
 docs = [
     { name = "myst-parser", extras = ["linkify"], specifier = ">=4.0.0,<5" },
@@ -367,7 +367,7 @@ docs = [
 ]
 lint = [
     { name = "ansible-lint", specifier = ">=26.6.0" },
-    { name = "ruff", specifier = ">=0.11.13,<0.12" },
+    { name = "ruff", specifier = ">=0.16.0,<0.17" },
 ]
 test = [{ name = "pytest", specifier = ">=9.0.3,<10" }]
 
@@ -1560,27 +1560,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.11.13"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ed/da/9c6f995903b4d9474b39da91d2d626659af3ff1eeb43e9ae7c119349dba6/ruff-0.11.13.tar.gz", hash = "sha256:26fa247dc68d1d4e72c179e08889a25ac0c7ba4d78aecfc835d49cbfd60bf514", size = 4282054, upload-time = "2025-06-05T21:00:15.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/ce/a11d381192966e0b4290842cc8d4fac7dc9214ddf627c11c1afff87da29b/ruff-0.11.13-py3-none-linux_armv6l.whl", hash = "sha256:4bdfbf1240533f40042ec00c9e09a3aade6f8c10b6414cf11b519488d2635d46", size = 10292516, upload-time = "2025-06-05T20:59:32.944Z" },
-    { url = "https://files.pythonhosted.org/packages/78/db/87c3b59b0d4e753e40b6a3b4a2642dfd1dcaefbff121ddc64d6c8b47ba00/ruff-0.11.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:aef9c9ed1b5ca28bb15c7eac83b8670cf3b20b478195bd49c8d756ba0a36cf48", size = 11106083, upload-time = "2025-06-05T20:59:37.03Z" },
-    { url = "https://files.pythonhosted.org/packages/77/79/d8cec175856ff810a19825d09ce700265f905c643c69f45d2b737e4a470a/ruff-0.11.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:53b15a9dfdce029c842e9a5aebc3855e9ab7771395979ff85b7c1dedb53ddc2b", size = 10436024, upload-time = "2025-06-05T20:59:39.741Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/5b/f6d94f2980fa1ee854b41568368a2e1252681b9238ab2895e133d303538f/ruff-0.11.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab153241400789138d13f362c43f7edecc0edfffce2afa6a68434000ecd8f69a", size = 10646324, upload-time = "2025-06-05T20:59:42.185Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/9c/b4c2acf24ea4426016d511dfdc787f4ce1ceb835f3c5fbdbcb32b1c63bda/ruff-0.11.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6c51f93029d54a910d3d24f7dd0bb909e31b6cd989a5e4ac513f4eb41629f0dc", size = 10174416, upload-time = "2025-06-05T20:59:44.319Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/10/e2e62f77c65ede8cd032c2ca39c41f48feabedb6e282bfd6073d81bb671d/ruff-0.11.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1808b3ed53e1a777c2ef733aca9051dc9bf7c99b26ece15cb59a0320fbdbd629", size = 11724197, upload-time = "2025-06-05T20:59:46.935Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/f0/466fe8469b85c561e081d798c45f8a1d21e0b4a5ef795a1d7f1a9a9ec182/ruff-0.11.13-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:d28ce58b5ecf0f43c1b71edffabe6ed7f245d5336b17805803312ec9bc665933", size = 12511615, upload-time = "2025-06-05T20:59:49.534Z" },
-    { url = "https://files.pythonhosted.org/packages/17/0e/cefe778b46dbd0cbcb03a839946c8f80a06f7968eb298aa4d1a4293f3448/ruff-0.11.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:55e4bc3a77842da33c16d55b32c6cac1ec5fb0fbec9c8c513bdce76c4f922165", size = 12117080, upload-time = "2025-06-05T20:59:51.654Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/2c/caaeda564cbe103bed145ea557cb86795b18651b0f6b3ff6a10e84e5a33f/ruff-0.11.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:633bf2c6f35678c56ec73189ba6fa19ff1c5e4807a78bf60ef487b9dd272cc71", size = 11326315, upload-time = "2025-06-05T20:59:54.469Z" },
-    { url = "https://files.pythonhosted.org/packages/75/f0/782e7d681d660eda8c536962920c41309e6dd4ebcea9a2714ed5127d44bd/ruff-0.11.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ffbc82d70424b275b089166310448051afdc6e914fdab90e08df66c43bb5ca9", size = 11555640, upload-time = "2025-06-05T20:59:56.986Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/d4/3d580c616316c7f07fb3c99dbecfe01fbaea7b6fd9a82b801e72e5de742a/ruff-0.11.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4a9ddd3ec62a9a89578c85842b836e4ac832d4a2e0bfaad3b02243f930ceafcc", size = 10507364, upload-time = "2025-06-05T20:59:59.154Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/dc/195e6f17d7b3ea6b12dc4f3e9de575db7983db187c378d44606e5d503319/ruff-0.11.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d237a496e0778d719efb05058c64d28b757c77824e04ffe8796c7436e26712b7", size = 10141462, upload-time = "2025-06-05T21:00:01.481Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/8e/39a094af6967faa57ecdeacb91bedfb232474ff8c3d20f16a5514e6b3534/ruff-0.11.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26816a218ca6ef02142343fd24c70f7cd8c5aa6c203bca284407adf675984432", size = 11121028, upload-time = "2025-06-05T21:00:04.06Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/c0/b0b508193b0e8a1654ec683ebab18d309861f8bd64e3a2f9648b80d392cb/ruff-0.11.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:51c3f95abd9331dc5b87c47ac7f376db5616041173826dfd556cfe3d4977f492", size = 11602992, upload-time = "2025-06-05T21:00:06.249Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/91/263e33ab93ab09ca06ce4f8f8547a858cc198072f873ebc9be7466790bae/ruff-0.11.13-py3-none-win32.whl", hash = "sha256:96c27935418e4e8e77a26bb05962817f28b8ef3843a6c6cc49d8783b5507f250", size = 10474944, upload-time = "2025-06-05T21:00:08.459Z" },
-    { url = "https://files.pythonhosted.org/packages/46/f4/7c27734ac2073aae8efb0119cae6931b6fb48017adf048fdf85c19337afc/ruff-0.11.13-py3-none-win_amd64.whl", hash = "sha256:29c3189895a8a6a657b7af4e97d330c8a3afd2c9c8f46c81e2fc5a31866517e3", size = 11548669, upload-time = "2025-06-05T21:00:11.147Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/bf/b273dd11673fed8a6bd46032c0ea2a04b2ac9bfa9c628756a5856ba113b0/ruff-0.11.13-py3-none-win_arm64.whl", hash = "sha256:b4385285e9179d608ff1d2fb9922062663c658605819a6876d8beef0c30b7f3b", size = 10683928, upload-time = "2025-06-05T21:00:13.758Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -354,7 +354,7 @@ dev = [
     { name = "anyio", specifier = ">=4.7.0,<5" },
     { name = "pyright", specifier = ">=1.1.350" },
     { name = "pytest", specifier = ">=9.0.3,<10" },
-    { name = "ruff", specifier = ">=0.16.0,<0.17" },
+    { name = "ruff", specifier = ">=0.16.1,<0.17" },
 ]
 docs = [
     { name = "myst-parser", extras = ["linkify"], specifier = ">=4.0.0,<5" },
@@ -367,7 +367,7 @@ docs = [
 ]
 lint = [
     { name = "ansible-lint", specifier = ">=26.6.0" },
-    { name = "ruff", specifier = ">=0.16.0,<0.17" },
+    { name = "ruff", specifier = ">=0.16.1,<0.17" },
 ]
 test = [{ name = "pytest", specifier = ">=9.0.3,<10" }]
 
@@ -1560,27 +1560,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.16.0"
+version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/25/7113f6d5498888c5fb7db34081cba7d5971c4cb1bfb26819966eee68f003/ruff-0.16.1.tar.gz", hash = "sha256:fedad7c801dabd3fb9741d76aca39246e6ddd9ca446a015875207bf19f1e6bc7", size = 4877500, upload-time = "2026-07-30T19:37:01.379Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
-    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
-    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
-    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
-    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
-    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
-    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
-    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/694da69368e0973de65df2ddc73ab18d43c469d5963d9b150911de6bc513/ruff-0.16.1-py3-none-linux_armv6l.whl", hash = "sha256:58edb313b88f0c5460a26adf5f39a37a3be789494a15e3e411e35fa78b89f9a0", size = 10839126, upload-time = "2026-07-30T19:36:13.697Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f0/b626e5d5bd0dd9576263658ef12885e2288afd1029a48e26ffed65ec1ac1/ruff-0.16.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fde5a99e2f97479af66edd6622c6d5a2a7592c77cf4153d9e4428f5eeb55b60c", size = 11070253, upload-time = "2026-07-30T19:36:17.14Z" },
+    { url = "https://files.pythonhosted.org/packages/83/63/f40acfb6b35b88623e71684942b552c3edd96035f5d98f313815f7b277de/ruff-0.16.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d4c20532fca4f7fa609369161d968dd28f65d83dabbd61d8e9c7edbf7001f6", size = 10561425, upload-time = "2026-07-30T19:36:20.04Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/14ec0e9c2b4d315547dd38765004b4863e354e1b52cb308272215d9f6f6d/ruff-0.16.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30affbcedf59ad5703d9c91f82266e02b47739f797e1a7b6e158e5526a6dae38", size = 10948879, upload-time = "2026-07-30T19:36:22.476Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e9/9d870cbae575030fdef595f04b4b97573c525b5497cce4f4498cf2f85446/ruff-0.16.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24e9c631573cbca9d20f1283f8f479b2afa4a8503504822bd71a293889f16743", size = 10643691, upload-time = "2026-07-30T19:36:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/09/12743d544e2173f53ecd27217c65f90d2bc0f8424a66a60339e56bbc0457/ruff-0.16.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b41bdd48fb420987a9b5212e4957c26ad4abce401fa9ea9d4d85843727945f4f", size = 11435354, upload-time = "2026-07-30T19:36:28.447Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/89/a1652b2daee52083c9554a6333b678a8b01d0400f976827bb87857f9449a/ruff-0.16.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b0d1e1393b7648079e13669de1c1f4fde06d4583e84d8fd5c1551e0a77a2aa75", size = 12259033, upload-time = "2026-07-30T19:36:31.326Z" },
+    { url = "https://files.pythonhosted.org/packages/16/96/ecdcb8c54ee7b123b487f807eb014e6e019155a0b81dfb669acd52f28ce3/ruff-0.16.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07bf434b1c95f4e093be4532068ef4fcf00924eb2ade8796075980902d6fd54a", size = 11667981, upload-time = "2026-07-30T19:36:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/90/c52e12e0d862e9572f2a33aa227409143520abe53111e9a6babbac7b4af8/ruff-0.16.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39897739f112253ee4fdd2e8aa9a4f9ded99fb2be367d5f31dfa4ded6025584c", size = 11468183, upload-time = "2026-07-30T19:36:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6b/4ffb7ad1d83eb16cf8cbb3c8815d3f11c88460fd162d4b372a2059be1c2a/ruff-0.16.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82ae3c0c0d74daf17b968a10b7b3bb3ef297ab7de0c1f749646b25e690ccb150", size = 11470071, upload-time = "2026-07-30T19:36:39.91Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/32ae7db4c0b5e32ab611787caa19d1546800676d79f7483b7100a3561bf4/ruff-0.16.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4d5f2ed10f8242d83fc08d521301089364e3375375705356f20c0e31606ef3ef", size = 10919503, upload-time = "2026-07-30T19:36:42.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/3d901ba6ad6fc38da39c3448fc6c59ac945679293a17c3ceb6d6c1cba13e/ruff-0.16.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a4665b309891f83f3e3c25447935f1213e9abbd4b5640af7a1f2def9f8d413c1", size = 10649861, upload-time = "2026-07-30T19:36:45.18Z" },
+    { url = "https://files.pythonhosted.org/packages/92/79/894ef1ced26552d5f8c9cf6d85b0687840e1128c55aeab7b9c2d54a0d880/ruff-0.16.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26e9ca5c9bc3971f20d3cf18a957f52ffd6a5f6564ff15c4912a144dcac22494", size = 11148137, upload-time = "2026-07-30T19:36:47.936Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/69/3609a09fa1cb46cc28b762363e440a354204e5dff01bd0c8d7437874d6b9/ruff-0.16.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:67e1e1e3fa4f0c82f0e36d4cd61e661f6e7a6196cb1aa92fe0828fa7b8f257cd", size = 11559211, upload-time = "2026-07-30T19:36:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/fb22af2fd78a736e241fabf67e30ce1799a64244026377a49e133af90762/ruff-0.16.1-py3-none-win32.whl", hash = "sha256:d31765e131295b8445caf301e3e8a85b34d1b9b211b4109b7ba457888b051806", size = 10838258, upload-time = "2026-07-30T19:36:53.298Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/35/e57fd9fb5d423961df087a00b12d42c0a830288dc2f3b45ecca299158b4f/ruff-0.16.1-py3-none-win_amd64.whl", hash = "sha256:09b05e8b90c2cb06ad63464350e7a45e8e44a2dfe52072ebfba6666ca8d3f596", size = 11961111, upload-time = "2026-07-30T19:36:56.107Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/240ea004bf6dc4feb40e9832f2205a476a47dd5b8a3f8211a5fc5f95e20e/ruff-0.16.1-py3-none-win_arm64.whl", hash = "sha256:dbaadaac38c70239f056d306b7476f246b0bf000fa6b3876402acbf5b227eaf8", size = 11309414, upload-time = "2026-07-30T19:36:58.79Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What and why?

This PR:
- Merges the following PRs into one:
  - https://github.com/Backblaze/boardwalk/pull/264
  - https://github.com/Backblaze/boardwalk/pull/253
  - https://github.com/Backblaze/boardwalk/pull/260
- TL;DR, this bumps Ruff, and the checkout action
- Performs linting to account for Ruff's newly introduced rules
- Adds a few additional tests to ensure Job options and required_options
  function as expected. (`test/boardwalk/test_manifest.py`)

Internal reference: OPSYSENG-1876

## How was this tested?

`ruff check`, `ruff format`, and `make test`. All local tests succeeded.

## Checklist
- [n/a] Have you updated the `version` in the `[project]` section of
the `pyproject.toml` file (if applicable)?
- No version bump needed.